### PR TITLE
Fix incorrect key changes

### DIFF
--- a/concent_api/core/tests/test_core_views.py
+++ b/concent_api/core/tests/test_core_views.py
@@ -141,7 +141,7 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 force_report_computed_task,
-                CONCENT_PRIVATE_KEY,
+                PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type = 'application/octet-stream',
@@ -160,7 +160,7 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 data,
-                CONCENT_PRIVATE_KEY,
+                PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type = 'application/octet-stream',
@@ -176,7 +176,7 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 self.correct_golem_data,
-                CONCENT_PRIVATE_KEY,
+                PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type = 'application/octet-stream',
@@ -192,7 +192,7 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 self.correct_golem_data,
-                CONCENT_PRIVATE_KEY,
+                PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type = 'application/octet-stream',
@@ -212,11 +212,11 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 self.want_to_compute,
-                CONCENT_PRIVATE_KEY,
+                PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY
             ),
             content_type                   = 'application/octet-stream',
-            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(CONCENT_PUBLIC_KEY).decode('ascii'),
+            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(PROVIDER_PUBLIC_KEY).decode('ascii'),
         )
 
         self.assertEqual(response_400.status_code, 400)
@@ -244,11 +244,11 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 ack_report_computed_task,
-                CONCENT_PRIVATE_KEY,
+                PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY
             ),
             content_type                    = 'application/octet-stream',
-            HTTP_CONCENT_CLIENT_PUBLIC_KEY  = b64encode(CONCENT_PUBLIC_KEY).decode('ascii'),
+            HTTP_CONCENT_CLIENT_PUBLIC_KEY  = b64encode(PROVIDER_PUBLIC_KEY).decode('ascii'),
         )
 
         self.assertEqual(response_400.status_code, 400)

--- a/concent_api/core/tests/test_core_views.py
+++ b/concent_api/core/tests/test_core_views.py
@@ -313,11 +313,7 @@ class CoreViewReceiveTest(TestCase):
         new_message         = Message(
             type        = self.force_golem_data.TYPE,
             timestamp   = message_timestamp,
-            data        = dump(
-                self.force_golem_data,
-                CONCENT_PRIVATE_KEY,
-                REQUESTOR_PUBLIC_KEY,
-            ),
+            data        = self.force_golem_data.serialize(),
             task_id     = self.task_to_compute.compute_task_def['task_id']  # pylint: disable=no-member
         )
         new_message.full_clean()
@@ -387,11 +383,7 @@ class CoreViewReceiveOutOfBandTest(TestCase):
         new_message         = Message(
             type        = self.force_golem_data.TYPE,
             timestamp   = message_timestamp,
-            data        = dump(
-                self.force_golem_data,
-                CONCENT_PRIVATE_KEY,
-                REQUESTOR_PUBLIC_KEY,
-            ),
+            data        = self.force_golem_data.serialize(),
             task_id     = self.force_golem_data.task_to_compute.compute_task_def['task_id'],
         )
         new_message.full_clean()

--- a/concent_api/core/tests/test_core_views.py
+++ b/concent_api/core/tests/test_core_views.py
@@ -141,11 +141,11 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 force_report_computed_task,
-                REQUESTOR_PRIVATE_KEY,
+                CONCENT_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type = 'application/octet-stream',
-            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(REQUESTOR_PUBLIC_KEY).decode('ascii')
+            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(PROVIDER_PUBLIC_KEY).decode('ascii')
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn('error', response.json().keys())
@@ -160,11 +160,11 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 data,
-                REQUESTOR_PRIVATE_KEY,
+                CONCENT_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type = 'application/octet-stream',
-            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(REQUESTOR_PUBLIC_KEY).decode('ascii'),
+            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(PROVIDER_PUBLIC_KEY).decode('ascii'),
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn('error', response.json().keys())
@@ -176,11 +176,11 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 self.correct_golem_data,
-                REQUESTOR_PRIVATE_KEY,
+                CONCENT_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type = 'application/octet-stream',
-            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(REQUESTOR_PUBLIC_KEY).decode('ascii')
+            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(PROVIDER_PUBLIC_KEY).decode('ascii'),
         )
 
         self.assertIsInstance(response_202, HttpResponse)
@@ -192,11 +192,11 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 self.correct_golem_data,
-                REQUESTOR_PRIVATE_KEY,
+                CONCENT_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type = 'application/octet-stream',
-            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(REQUESTOR_PUBLIC_KEY).decode('ascii'),
+            HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(PROVIDER_PUBLIC_KEY).decode('ascii'),
         )
 
         self.assertIsInstance(response_400, JsonResponse)
@@ -244,11 +244,11 @@ class CoreViewSendTest(TestCase):
             reverse('core:send'),
             data = dump(
                 ack_report_computed_task,
-                PROVIDER_PRIVATE_KEY,
+                CONCENT_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY
             ),
             content_type                    = 'application/octet-stream',
-            HTTP_CONCENT_CLIENT_PUBLIC_KEY  = b64encode(PROVIDER_PUBLIC_KEY).decode('ascii'),
+            HTTP_CONCENT_CLIENT_PUBLIC_KEY  = b64encode(CONCENT_PUBLIC_KEY).decode('ascii'),
         )
 
         self.assertEqual(response_400.status_code, 400)
@@ -313,7 +313,11 @@ class CoreViewReceiveTest(TestCase):
         new_message         = Message(
             type        = self.force_golem_data.TYPE,
             timestamp   = message_timestamp,
-            data        = self.force_golem_data.serialize(),
+            data        = dump(
+                self.force_golem_data,
+                CONCENT_PRIVATE_KEY,
+                REQUESTOR_PUBLIC_KEY,
+            ),
             task_id     = self.task_to_compute.compute_task_def['task_id']  # pylint: disable=no-member
         )
         new_message.full_clean()
@@ -385,8 +389,8 @@ class CoreViewReceiveOutOfBandTest(TestCase):
             timestamp   = message_timestamp,
             data        = dump(
                 self.force_golem_data,
-                REQUESTOR_PRIVATE_KEY,
-                CONCENT_PUBLIC_KEY,
+                CONCENT_PRIVATE_KEY,
+                REQUESTOR_PUBLIC_KEY,
             ),
             task_id     = self.force_golem_data.task_to_compute.compute_task_def['task_id'],
         )

--- a/concent_api/core/tests/test_integration_report_computed_task.py
+++ b/concent_api/core/tests/test_integration_report_computed_task.py
@@ -483,7 +483,7 @@ class ReportComputedTaskIntegrationTest(TestCase):
                 reverse('core:receive'),
                 data         = '',
                 content_type = '',
-                HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(REQUESTOR_PUBLIC_KEY).decode('ascii'),
+                HTTP_CONCENT_CLIENT_PUBLIC_KEY = b64encode(PROVIDER_PUBLIC_KEY).decode('ascii'),
             )
 
         self.assertEqual(response_3.status_code,  200)

--- a/concent_api/core/tests/test_integration_report_computed_task.py
+++ b/concent_api/core/tests/test_integration_report_computed_task.py
@@ -488,7 +488,7 @@ class ReportComputedTaskIntegrationTest(TestCase):
 
         self.assertEqual(response_3.status_code,  200)
 
-        message_from_concent_to_provider = load(response_3.content, REQUESTOR_PRIVATE_KEY, CONCENT_PUBLIC_KEY, check_time=False)
+        message_from_concent_to_provider = load(response_3.content, PROVIDER_PRIVATE_KEY, CONCENT_PUBLIC_KEY, check_time=False)
 
         self.assertIsInstance(message_from_concent_to_provider, message.AckReportComputedTask)
         self.assertGreaterEqual(message_from_concent_to_provider.timestamp, int(dateutil.parser.parse("2017-12-01 11:00:05").timestamp()))

--- a/concent_api/core/views.py
+++ b/concent_api/core/views.py
@@ -9,7 +9,6 @@ from django.conf                    import settings
 
 from golem_messages                 import message
 from golem_messages.exceptions      import InvalidSignature
-from golem_messages.shortcuts       import dump
 from golem_messages.shortcuts       import load
 
 from utils.api_view                 import api_view
@@ -177,11 +176,7 @@ def receive(request, _message):
 
             ack_report_computed_task                 = message.AckReportComputedTask()
             ack_report_computed_task.task_to_compute = decoded_message_data.task_to_compute
-            return dump(
-                ack_report_computed_task,
-                settings.CONCENT_PRIVATE_KEY,
-                client_public_key,
-            )
+            return ack_report_computed_task
     else:
         last_undelivered_message_status.delivered = True
         last_undelivered_message_status.full_clean()

--- a/concent_api/core/views.py
+++ b/concent_api/core/views.py
@@ -1,15 +1,11 @@
 import datetime
-from base64                         import b64decode
 
 from django.http                    import HttpResponse
-from django.http                    import JsonResponse
 from django.views.decorators.http   import require_POST
 from django.utils                   import timezone
 from django.conf                    import settings
 
 from golem_messages                 import message
-from golem_messages.exceptions      import InvalidSignature
-from golem_messages.shortcuts       import load
 
 from utils.api_view                 import api_view
 from utils.api_view                 import Http400
@@ -33,6 +29,7 @@ def send(_request, client_message):
             reject_force_report_computed_task.reason          = message.RejectReportComputedTask.Reason.TASK_TIME_LIMIT_EXCEEDED
             reject_force_report_computed_task.task_to_compute = client_message.task_to_compute
             return reject_force_report_computed_task
+        client_message.sig = None
         golem_message, message_timestamp = store_message(
             client_message.TYPE,
             client_message.task_to_compute.compute_task_def['task_id'],
@@ -92,7 +89,8 @@ def send(_request, client_message):
 
         assert force_report_computed_task.task_to_compute.compute_task_def['task_id'] == client_message.cannot_compute_task.task_to_compute.compute_task_def['task_id']
         if client_message.cannot_compute_task.reason == message.CannotComputeTask.REASON.WrongCTD:
-            store_message(
+            client_message.sig = None
+            golem_message, message_timestamp = store_message(
                 client_message.TYPE,
                 force_report_computed_task.task_to_compute.compute_task_def['task_id'],
                 client_message.serialize()
@@ -106,6 +104,7 @@ def send(_request, client_message):
             if ack_message.exists() or previous_reject_message.exists():
                 raise Http400("Received RejectReportComputedTask but AckReportComputedTask or another RejectReportComputedTask for this task has already been submitted.")
 
+            client_message.sig = None
             golem_message, message_timestamp = store_message(
                 client_message.TYPE,
                 force_report_computed_task.task_to_compute.compute_task_def['task_id'],
@@ -127,8 +126,7 @@ def send(_request, client_message):
 
 @api_view
 @require_POST
-def receive(request, _message):
-    client_public_key               = decode_client_public_key(request)
+def receive(_request, _message):
     last_undelivered_message_status = ReceiveStatus.objects.filter(delivered = False).order_by('timestamp').last()
     if last_undelivered_message_status is None:
         last_delivered_message_status = ReceiveStatus.objects.all().order_by('timestamp').last()
@@ -201,15 +199,12 @@ def receive(request, _message):
             task_id = decoded_message_data.cannot_compute_task.task_to_compute.compute_task_def['task_id']
         )
         raw_force_report_computed_task = force_report_computed_task.data.tobytes()
-        try:
-            decoded_message_from_database = load(
-                raw_force_report_computed_task,
-                settings.CONCENT_PRIVATE_KEY,
-                client_public_key,
-                check_time = False,
-            )
-        except InvalidSignature as exception:
-            return JsonResponse({'error': "Failed to decode ForceReportComputedTask. {}".format(exception)}, status = 400)
+
+        decoded_message_from_database = message.Message.deserialize(
+            raw_force_report_computed_task,
+            None,
+            check_time = False
+        )
 
         if current_time <= decoded_message_from_database.task_to_compute.compute_task_def['deadline'] + 2 * settings.CONCENT_MESSAGING_TIME:
             if decoded_message_data.reason is not None and decoded_message_data.reason == message.RejectReportComputedTask.Reason.TASK_TIME_LIMIT_EXCEEDED:
@@ -236,11 +231,10 @@ def receive(request, _message):
 
 @api_view
 @require_POST
-def receive_out_of_band(request, _message):
+def receive_out_of_band(_request, _message):
     undelivered_receive_out_of_band_statuses    = ReceiveOutOfBandStatus.objects.filter(delivered = False)
     last_undelivered_receive_out_of_band_status = undelivered_receive_out_of_band_statuses.order_by('timestamp').last()
     last_undelivered_receive_status             = Message.objects.all().order_by('timestamp').last()
-    client_public_key                           = decode_client_public_key(request)
 
     current_time    = int(datetime.datetime.now().timestamp())
     message_verdict = message.VerdictReportComputedTask()
@@ -255,15 +249,11 @@ def receive_out_of_band(request, _message):
         if last_undelivered_receive_status.type == message.AckReportComputedTask.TYPE:
             serialized_ack_report_computed_task = last_undelivered_receive_status.data.tobytes()
 
-            try:
-                decoded_ack_report_computed_task = message.Message.deserialize(
-                    serialized_ack_report_computed_task,
-                    None,
-                    check_time = False
-                )
-
-            except InvalidSignature as exception:
-                return JsonResponse({'error': "Failed to decode AckReportComputedTask. {}".format(exception)}, status = 400)
+            decoded_ack_report_computed_task = message.Message.deserialize(
+                serialized_ack_report_computed_task,
+                None,
+                check_time = False
+            )
 
             force_report_computed_task = message.ForceReportComputedTask()
             force_report_computed_task.task_to_compute = decoded_ack_report_computed_task.task_to_compute
@@ -281,15 +271,12 @@ def receive_out_of_band(request, _message):
 
         if last_undelivered_receive_status.type == message.ForceReportComputedTask.TYPE:
             serialized_force_report_computed_task = last_undelivered_receive_status.data.tobytes()
-            try:
-                decoded_force_report_computed_task = load(
-                    serialized_force_report_computed_task,
-                    settings.CONCENT_PRIVATE_KEY,
-                    client_public_key,
-                    check_time = False
-                )
-            except InvalidSignature as exception:
-                return JsonResponse({'error': "Failed to decode ForceReportComputedTask. {}".format(exception)}, status = 400)
+
+            decoded_force_report_computed_task = message.Message.deserialize(
+                serialized_force_report_computed_task,
+                None,
+                check_time = False
+            )
 
             ack_report_computed_task                    = message.AckReportComputedTask()
             ack_report_computed_task.task_to_compute    = decoded_force_report_computed_task.task_to_compute
@@ -345,14 +332,12 @@ def receive_out_of_band(request, _message):
             rejected_task_id               = decoded_last_task_message.message_cannot_compute_task.task_to_compute.compute_task_def['task_id']
             force_report_computed_task     = Message.objects.get(type = message.ForceReportComputedTask.TYPE, task_id = rejected_task_id)
             raw_force_report_computed_task = force_report_computed_task.data.tobytes()
-            try:
-                force_report_computed_task     = load(
-                    raw_force_report_computed_task,
-                    settings.CONCENT_PRIVATE_KEY,
-                    client_public_key
-                )
-            except InvalidSignature as exception:
-                return JsonResponse({'error': "Failed to decode ForceReportComputedTask. {}".format(exception)}, status = 400)
+
+            force_report_computed_task = message.Message.deserialize(
+                raw_force_report_computed_task,
+                None,
+                check_time = False
+            )
 
             message_ack_report_computed_task.task_to_compute = force_report_computed_task.task_to_compute
             message_verdict.ack_report_computed_task         = message_ack_report_computed_task
@@ -430,7 +415,3 @@ def store_receive_out_of_band(golem_message, message_timestamp):
     )
     receive_out_of_band_status.full_clean()
     receive_out_of_band_status.save()
-
-
-def decode_client_public_key(request):
-    return b64decode(request.META['HTTP_CONCENT_CLIENT_PUBLIC_KEY'].encode('ascii'), validate = True)


### PR DESCRIPTION
Resolves #43 Reverted old key changes commits which were wrong and added fix to repair them.

To make views working after key changes had to be changed also method of serialization messages to database and getting them from database.