### PR TITLE
Pylint and pylint django update

### DIFF
--- a/concent_api/gatekeeper/views.py
+++ b/concent_api/gatekeeper/views.py
@@ -14,10 +14,10 @@ from django.views.decorators.csrf   import csrf_exempt
 from django.views.decorators.http   import require_POST
 from django.views.decorators.http   import require_safe
 
-from gatekeeper.utils               import gatekeeper_access_denied_response
-
 from golem_messages.message         import Message
 from golem_messages.shortcuts       import load
+
+from gatekeeper.utils               import gatekeeper_access_denied_response
 
 
 logger = logging.getLogger(__name__)

--- a/concent_api/utils/api_view.py
+++ b/concent_api/utils/api_view.py
@@ -75,5 +75,6 @@ def api_view(view):
             return HttpResponse(response_from_view)
 
         assert False, "Invalid response type"
+        raise Exception("Invalid response type")
 
     return wrapper

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -5,21 +5,12 @@ ipdb
 ipython
 pipdeptree
 flake8
-pylint-django
 requests
 mypy
 coverage
 
 # Force the latest version of pylint pyflakes and pep8. There are numerous issues with older versions.
-# FIXME: pylint-django does not work with the latest pylint (1.8.0 or 1.8.1).
-# See https://github.com/landscapeio/pylint-django/issues/108
-# Remove the upper limit when the problem gets resolved.
-pylint   >= 1.7.5, < 1.8.0
-pyflakes >= 1.6.0
-pep8     >= 1.7.1
-
-# FIXME: There's a bug in astroid that makes pylint print spurious warnings about unused __class__ variable.
-# https://github.com/PyCQA/pylint/issues/1609
-# It's fixed in pylint 1.8.1 but we can't upgrade yet because pylint-django does not work with pylint 1.8.1 yet.
-# When it's fixed, remove the line below and start requiring pylint version >= 1.8.1.
-astroid < 1.6.0
+pylint        >= 1.8.2
+pylint-django >= 0.9.0
+pyflakes      >= 1.6.0
+pep8          >= 1.7.1


### PR DESCRIPTION
The latest `pylint-django` (0.9.0) does not work with the older pylint. Fortunately our earlier issues have been resolved so instead of pinning it to an older version I just updated all of them to the latest versions.