### PR TITLE
gatekeeper.tests: Json.loads bugfix

### DIFF
--- a/concent_api/gatekeeper/tests/test_utils.py
+++ b/concent_api/gatekeeper/tests/test_utils.py
@@ -22,7 +22,7 @@ class GatekeeperAccessDeniedResponseTest(TestCase):
             None,
             self.client_key
         )
-        response_body = json.loads(response.content)
+        response_body = json.loads(response.content.decode())
 
         self.assertIsInstance(response, JsonResponse)
         self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
Fix for:
```
ERROR: test_gatekeeper_access_denied_response_should_return_appropriate_body_and_headers (gatekeeper.tests.test_utils.GatekeeperAccessDeniedResponseTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jakub/Documents/work/projects/concent/concent_api/gatekeeper/tests/test_utils.py", line 26, in test_gatekeeper_access_denied_response_should_return_appropriate_body_and_headers
    response_body = json.loads(response.content)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```