### PR TITLE
Fix for message signature clearing

### DIFF
--- a/concent_api/core/tests/test_core_views.py
+++ b/concent_api/core/tests/test_core_views.py
@@ -231,9 +231,6 @@ class CoreViewSendTest(TestCase):
         self.assertIsInstance(response_202, HttpResponse)
         self.assertEqual(response_202.status_code, 202)
         self.correct_golem_data.encrypted                                   = None
-        self.correct_golem_data.sig                                         = None
-        self.correct_golem_data.report_computed_task.sig                    = None
-        self.correct_golem_data.report_computed_task.task_to_compute.sig    = None
         response_400 = self.client.post(
             reverse('core:send'),
             data = dump(
@@ -601,7 +598,6 @@ class CoreViewReceiveTest(TestCase):
         self.assertEqual(undelivered_messages,                                                      0)
         self.assertEqual(decoded_message.timestamp,                                                 int(dateutil.parser.parse("2017-11-17 12:00:00").timestamp()))
         self.assertEqual(decoded_message.ack_report_computed_task.task_to_compute.compute_task_def, self.task_to_compute.compute_task_def)  # pylint: disable=no-member
-        self.assertEqual(decoded_message.ack_report_computed_task.task_to_compute.sig,              self.task_to_compute.sig)
         self.assertEqual(decoded_message.ack_report_computed_task.subtask_id,                       None)
 
 

--- a/concent_api/core/tests/utils.py
+++ b/concent_api/core/tests/utils.py
@@ -476,7 +476,6 @@ class ConcentIntegrationTestCase(TestCase):
     ):
         with freeze_time(timestamp or self._get_timestamp_string()):
             message_timestamp = datetime.datetime.now(timezone.utc)
-            data.sig = None
             golem_message = StoredMessage(
                 type        = message_type,
                 timestamp   = message_timestamp,

--- a/concent_api/utils/api_view.py
+++ b/concent_api/utils/api_view.py
@@ -81,6 +81,7 @@ def api_view(view):
             )
             return JsonResponse({'error': str(exception)}, status = 400)
         if isinstance(response_from_view, Message):
+            assert response_from_view.sig is None
             logging.log_message_returned(
                 response_from_view,
                 request.META['HTTP_CONCENT_CLIENT_PUBLIC_KEY'],


### PR DESCRIPTION
Resolves https://github.com/golemfactory/concent/issues/145.

This is just a fix proposal. The original issue is caused when `.serialize()` method is called on message, and no `sign_func` parameter is provided, method is calling `_fake_sign` to set the `.sig` to:

```
def _fake_sign(_):
    return b'\0' * Message.SIG_LEN
```

Which cause issues on loading that message. 

In my solution we don't need to worry and remember about clearing this overwritten signature, but we still, on few occasions, store messages with this overwritten signature in database (when there is no original signature, so when the message was created by concent). However, there is no harm because we never send them back to client.

The other solutions might be:
1. Report this as bug to golem-messages.
2. Keep the current solution.
3. Use different serialization method for storing messages in database (ie. pickle).
4. Use the same `sign_func` as `dump` function and sign message with concent keys
`functools.partial(cryptography.ecdsa_sign, privkey)`

Please let me know what do you guys think about this.