### PR TITLE
Chore enhance file transfer token creation

### DIFF
--- a/concent_api/api-integration-force-get-task-result-test.py
+++ b/concent_api/api-integration-force-get-task-result-test.py
@@ -5,12 +5,13 @@ import sys
 import hashlib
 import time
 import random
-from base64                 import b64encode
+from base64 import b64encode
 
-from golem_messages         import message
-from golem_messages         import shortcuts
+from golem_messages import message
+from golem_messages import shortcuts
 
 from utils.helpers import get_current_utc_timestamp
+from utils.helpers import get_storage_file_path
 from utils.helpers import sign_message
 from utils.testing_helpers import generate_ecc_key_pair
 
@@ -18,7 +19,7 @@ from api_testing_common import api_request
 from api_testing_common import create_client_auth_message
 from api_testing_common import timestamp_to_isoformat
 
-from freezegun              import freeze_time
+from freezegun import freeze_time
 
 from protocol_constants import get_protocol_constants
 
@@ -46,7 +47,7 @@ def upload_new_file_on_cluster(task_id, subtask_id, cluster_consts, current_time
     file_content    = task_id
     file_size       = len(file_content)
     file_check_sum  = 'sha1:' + hashlib.sha1(file_content.encode()).hexdigest()
-    file_path       = 'blender/result/{}/{}.{}.zip'.format(task_id, task_id, subtask_id)
+    file_path       = get_storage_file_path(task_id, subtask_id)
 
     file_transfer_token = message.FileTransferToken()
     file_transfer_token.token_expiration_deadline = int(
@@ -69,10 +70,10 @@ def upload_new_file_on_cluster(task_id, subtask_id, cluster_consts, current_time
     authorized_golem_transfer_token = 'Golem ' + encrypted_token
 
     headers = {
-        'Authorization': authorized_golem_transfer_token,
-        'Concent-Client-Public-Key': b64encode(CONCENT_PUBLIC_KEY).decode(),
-        'Concent-upload-path': 'blender/result/{}/{}.{}.zip'.format(task_id, task_id, subtask_id),
-        'Content-Type': 'application/octet-stream'
+            'Authorization': authorized_golem_transfer_token,
+            'Concent-Client-Public-Key': b64encode(CONCENT_PUBLIC_KEY).decode(),
+            'Concent-upload-path': file_path,
+            'Content-Type': 'application/octet-stream'
     }
 
     response = requests.post("{}".format(STORAGE_CLUSTER_ADDRESS + 'upload/'), headers = headers, data = file_content, verify = False)

--- a/concent_api/api-integration-force-get-task-result-test.py
+++ b/concent_api/api-integration-force-get-task-result-test.py
@@ -57,7 +57,7 @@ def upload_new_file_on_cluster(task_id, subtask_id, cluster_consts, current_time
     )
     file_transfer_token.storage_cluster_address         = STORAGE_CLUSTER_ADDRESS
     file_transfer_token.authorized_client_public_key    = CONCENT_PUBLIC_KEY
-    file_transfer_token.operation                       = 'upload'
+    file_transfer_token.operation                       = message.FileTransferToken.Operation.upload
 
     file_transfer_token.files                   = [message.FileTransferToken.FileInfo()]
     file_transfer_token.files[0]['path']        = file_path

--- a/concent_api/api-integration-force-report-computed-task-test.py
+++ b/concent_api/api-integration-force-report-computed-task-test.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import random
-from base64 import b64encode
 
 from golem_messages.message.tasks import AckReportComputedTask
 from golem_messages.message         import ComputeTaskDef

--- a/concent_api/core/message_handlers.py
+++ b/concent_api/core/message_handlers.py
@@ -1,34 +1,35 @@
 import datetime
 
 import copy
-from base64                         import b64encode
+from base64 import b64encode
 from typing import Optional
 
-from django.conf                    import settings
-from django.http                    import HttpResponse
-from django.utils                   import timezone
-from golem_messages                 import message
-from golem_messages.datastructures  import MessageHeader
+from django.conf import settings
+from django.http import HttpResponse
+from django.utils import timezone
+from golem_messages import message
+from golem_messages.datastructures import MessageHeader
+from golem_messages.message import FileTransferToken
 
-from core.exceptions                import Http400
-from core.models                    import Client
-from core.models                    import PaymentInfo
-from core.models                    import PendingResponse
-from core.models                    import StoredMessage
-from core.models                    import Subtask
-from core.payments                  import base
-from core.validation                import validate_golem_message_reject
-from core.validation                import validate_task_to_compute
-from core.validation                import validate_report_computed_task_time_window
-from core.validation                import validate_list_of_identical_task_to_compute
-from core.validation                import validate_golem_message_signed_with_key
-from core.subtask_helpers           import verify_message_subtask_results_accepted
-from core.transfer_operations       import store_pending_message
-from core.transfer_operations       import create_file_transfer_token
-from utils                          import logging
-from utils.helpers                  import deserialize_message
-from utils.helpers                  import get_current_utc_timestamp
-from utils.helpers                  import parse_timestamp_to_utc_datetime
+from core.exceptions import Http400
+from core.models import Client
+from core.models import PaymentInfo
+from core.models import PendingResponse
+from core.models import StoredMessage
+from core.models import Subtask
+from core.payments import base
+from core.validation import validate_golem_message_reject
+from core.validation import validate_task_to_compute
+from core.validation import validate_report_computed_task_time_window
+from core.validation import validate_list_of_identical_task_to_compute
+from core.validation import validate_golem_message_signed_with_key
+from core.subtask_helpers import verify_message_subtask_results_accepted
+from core.transfer_operations import store_pending_message
+from core.transfer_operations import create_file_transfer_token
+from utils import logging
+from utils.helpers import deserialize_message
+from utils.helpers import get_current_utc_timestamp
+from utils.helpers import parse_timestamp_to_utc_datetime
 
 
 def handle_send_force_report_computed_task(client_message):
@@ -750,7 +751,7 @@ def handle_messages_from_database(
         file_transfer_token     = create_file_transfer_token(
             report_computed_task,
             encoded_client_public_key,
-            'upload',
+            FileTransferToken.Operation.upload,
         )
 
         response_to_client = message.concents.ForceGetTaskResultUpload(
@@ -767,7 +768,7 @@ def handle_messages_from_database(
         file_transfer_token     = create_file_transfer_token(
             report_computed_task,
             encoded_client_public_key,
-            'download',
+            FileTransferToken.Operation.download,
         )
 
         response_to_client = message.concents.ForceGetTaskResultDownload(

--- a/concent_api/core/tests/test_auth_get_task_result.py
+++ b/concent_api/core/tests/test_auth_get_task_result.py
@@ -5,6 +5,7 @@ from django.urls            import reverse
 from freezegun              import freeze_time
 from golem_messages         import load
 from golem_messages         import message
+from golem_messages.message import FileTransferToken
 
 from core.models            import PendingResponse
 from core.models            import Subtask
@@ -350,7 +351,7 @@ class AuthGetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_file_transfer_token.subtask_id,                deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_file_transfer_token.timestamp,                 self._parse_iso_date_to_timestamp("2017-12-01 11:00:02"))
         self.assertEqual(message_file_transfer_token.token_expiration_deadline, self._parse_iso_date_to_timestamp("2017-12-01 11:00:50"))
-        self.assertEqual(message_file_transfer_token.operation,                 'upload')
+        self.assertEqual(message_file_transfer_token.operation, FileTransferToken.Operation.upload)
 
         self._assert_stored_message_counter_not_increased()
 
@@ -584,7 +585,7 @@ class AuthGetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_file_transfer_token.subtask_id,                deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_file_transfer_token.timestamp,                 self._parse_iso_date_to_timestamp("2017-12-01 11:00:03"))
         self.assertEqual(message_file_transfer_token.token_expiration_deadline, self._parse_iso_date_to_timestamp("2017-12-01 11:00:50"))
-        self.assertEqual(message_file_transfer_token.operation,                 'upload')
+        self.assertEqual(message_file_transfer_token.operation, FileTransferToken.Operation.upload)
 
         self._assert_stored_message_counter_not_increased()
 
@@ -810,7 +811,7 @@ class AuthGetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_file_transfer_token.subtask_id,                deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_file_transfer_token.timestamp,                 self._parse_iso_date_to_timestamp("2017-12-01 11:00:02"))
         self.assertEqual(message_file_transfer_token.token_expiration_deadline, self._parse_iso_date_to_timestamp("2017-12-01 11:00:50"))
-        self.assertEqual(message_file_transfer_token.operation,                 'upload')
+        self.assertEqual(message_file_transfer_token.operation, FileTransferToken.Operation.upload)
 
         self._assert_stored_message_counter_not_increased()
 
@@ -1036,7 +1037,7 @@ class AuthGetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_file_transfer_token.subtask_id,                deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_file_transfer_token.timestamp,                 self._parse_iso_date_to_timestamp("2017-12-01 11:00:02"))
         self.assertEqual(message_file_transfer_token.token_expiration_deadline, self._parse_iso_date_to_timestamp("2017-12-01 11:00:50"))
-        self.assertEqual(message_file_transfer_token.operation,                 'upload')
+        self.assertEqual(message_file_transfer_token.operation, FileTransferToken.Operation.upload)
 
         self._assert_stored_message_counter_not_increased()
 
@@ -1112,7 +1113,7 @@ class AuthGetTaskResultIntegrationTest(ConcentIntegrationTestCase):
             message_from_concent.file_transfer_token.token_expiration_deadline,
             self._parse_iso_date_to_timestamp("2017-12-01 11:30:00")
         )
-        self.assertEqual(message_from_concent.file_transfer_token.operation, 'download')
+        self.assertEqual(message_from_concent.file_transfer_token.operation, FileTransferToken.Operation.download)
 
         self._assert_stored_message_counter_not_increased()
         self._test_subtask_state(

--- a/concent_api/core/tests/test_integration_get_task_result.py
+++ b/concent_api/core/tests/test_integration_get_task_result.py
@@ -5,6 +5,7 @@ from django.urls            import reverse
 from freezegun              import freeze_time
 from golem_messages         import load
 from golem_messages         import message
+from golem_messages.message import FileTransferToken
 
 from core.tests.utils       import ConcentIntegrationTestCase
 from core.models            import PendingResponse
@@ -349,7 +350,7 @@ class GetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_file_transfer_token.subtask_id, deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_file_transfer_token.timestamp, self._parse_iso_date_to_timestamp("2017-12-01 11:00:12"))
         self.assertEqual(message_file_transfer_token.token_expiration_deadline, self._parse_iso_date_to_timestamp("2017-12-01 11:00:50"))
-        self.assertEqual(message_file_transfer_token.operation, 'upload')
+        self.assertEqual(message_file_transfer_token.operation, FileTransferToken.Operation.upload)
 
         # STEP 3: Requestor receives force get task result failed due to lack of provider submit.
         with mock.patch('core.transfer_operations.request_upload_status', request_upload_status_false_mock):
@@ -600,7 +601,7 @@ class GetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_file_transfer_token.subtask_id,                deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_file_transfer_token.timestamp,                 self._parse_iso_date_to_timestamp("2017-12-01 11:00:06"))
         self.assertEqual(message_file_transfer_token.token_expiration_deadline, self._parse_iso_date_to_timestamp("2017-12-01 11:00:50"))
-        self.assertEqual(message_file_transfer_token.operation,                 'upload')
+        self.assertEqual(message_file_transfer_token.operation, FileTransferToken.Operation.upload)
 
         # STEP 3: Requestor receives force get task result upload.
         with mock.patch('core.transfer_operations.request_upload_status', request_upload_status_true_mock):
@@ -633,7 +634,7 @@ class GetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_from_concent.file_transfer_token.subtask_id,                               deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_from_concent.file_transfer_token.timestamp,                                self._parse_iso_date_to_timestamp("2017-12-01 11:00:21"))
         self.assertEqual(message_from_concent.file_transfer_token.token_expiration_deadline,                self._parse_iso_date_to_timestamp("2017-12-01 11:30:00"))
-        self.assertEqual(message_from_concent.file_transfer_token.operation,                                'download')
+        self.assertEqual(message_from_concent.file_transfer_token.operation, FileTransferToken.Operation.download)
 
         self._assert_client_count_is_equal(2)
 
@@ -745,7 +746,7 @@ class GetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_file_transfer_token.subtask_id,                deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_file_transfer_token.timestamp,                 self._parse_iso_date_to_timestamp("2017-12-01 11:00:12"))
         self.assertEqual(message_file_transfer_token.token_expiration_deadline, self._parse_iso_date_to_timestamp("2017-12-01 11:00:50"))
-        self.assertEqual(message_file_transfer_token.operation,                 'upload')
+        self.assertEqual(message_file_transfer_token.operation, FileTransferToken.Operation.upload)
 
         # STEP 3: Requestor receives force get task result failed due to lack of provider submit.
         with mock.patch('core.transfer_operations.request_upload_status', request_upload_status_true_mock):
@@ -892,7 +893,7 @@ class GetTaskResultIntegrationTest(ConcentIntegrationTestCase):
         self.assertEqual(message_file_transfer_token.subtask_id, deserialized_task_to_compute.compute_task_def['subtask_id'])  # pylint: disable=no-member
         self.assertEqual(message_file_transfer_token.timestamp, self._parse_iso_date_to_timestamp("2017-12-01 11:00:12"))
         self.assertEqual(message_file_transfer_token.token_expiration_deadline, self._parse_iso_date_to_timestamp("2017-12-01 11:00:50"))
-        self.assertEqual(message_file_transfer_token.operation, 'upload')
+        self.assertEqual(message_file_transfer_token.operation, FileTransferToken.Operation.upload)
 
         # STEP 3: Requestor receives force get task result download because Provider uploaded file.
         with mock.patch('core.transfer_operations.request_upload_status', request_upload_status_true_mock):
@@ -944,6 +945,6 @@ class GetTaskResultIntegrationTest(ConcentIntegrationTestCase):
             message_from_concent.file_transfer_token.token_expiration_deadline,
             self._parse_iso_date_to_timestamp("2017-12-01 11:30:00")
         )
-        self.assertEqual(message_from_concent.file_transfer_token.operation, 'download')
+        self.assertEqual(message_from_concent.file_transfer_token.operation, FileTransferToken.Operation.download)
 
         self._assert_client_count_is_equal(2)

--- a/concent_api/core/tests/test_unit_transfer_operation.py
+++ b/concent_api/core/tests/test_unit_transfer_operation.py
@@ -1,13 +1,15 @@
-from django.test                    import override_settings
+from django.test import override_settings
 import mock
 
-from core.tests.utils               import ConcentIntegrationTestCase
-from core.exceptions                import UnexpectedResponse
+from golem_messages.message import FileTransferToken
 
-from core.transfer_operations       import create_file_transfer_token
-from core.transfer_operations       import request_upload_status
+from core.tests.utils import ConcentIntegrationTestCase
+from core.exceptions import UnexpectedResponse
 
-from utils.testing_helpers          import generate_ecc_key_pair
+from core.transfer_operations import create_file_transfer_token
+from core.transfer_operations import request_upload_status
+
+from utils.testing_helpers import generate_ecc_key_pair
 
 
 def mock_send_request_to_cluster_correct_response(_headers, _request_http):
@@ -48,7 +50,7 @@ class RequestUploadStatusTest(ConcentIntegrationTestCase):
         file_transfer_token = create_file_transfer_token(
             report_computed_task,
             self.REQUESTOR_PUBLIC_KEY,
-            'upload',
+            FileTransferToken.Operation.upload,
         )
 
         with mock.patch('core.transfer_operations.send_request_to_cluster_storage', mock_send_request_to_cluster_correct_response):

--- a/concent_api/core/transfer_operations.py
+++ b/concent_api/core/transfer_operations.py
@@ -1,24 +1,25 @@
 import datetime
 
-from base64                 import b64encode
+from base64 import b64encode
 
 import requests
 
-from django.conf            import settings
-from django.utils           import timezone
-from golem_messages         import message
-from golem_messages         import shortcuts
+from django.conf import settings
+from django.utils import timezone
+from golem_messages import message
+from golem_messages import shortcuts
 
-from core                   import exceptions
-from core.models            import Client
-from core.models            import PaymentInfo
-from core.models            import PendingResponse
-from core.models            import Subtask
-from gatekeeper.constants   import CLUSTER_DOWNLOAD_PATH
-from utils                  import logging
-from utils.helpers          import decode_key
-from utils.helpers          import deserialize_message
-from utils.helpers          import sign_message
+from core import exceptions
+from core.models import Client
+from core.models import PaymentInfo
+from core.models import PendingResponse
+from core.models import Subtask
+from gatekeeper.constants import CLUSTER_DOWNLOAD_PATH
+from utils import logging
+from utils.helpers import decode_key
+from utils.helpers import deserialize_message
+from utils.helpers import get_storage_file_path
+from utils.helpers import sign_message
 
 
 def verify_file_status(
@@ -111,7 +112,7 @@ def create_file_transfer_token(
     """
     task_id         = report_computed_task.task_to_compute.compute_task_def['task_id']
     subtask_id      = report_computed_task.task_to_compute.compute_task_def['subtask_id']
-    file_path       = 'blender/result/{}/{}.{}.zip'.format(task_id, task_id, subtask_id)
+    file_path       = get_storage_file_path(subtask_id, task_id)
 
     assert isinstance(encoded_client_public_key, bytes)
     assert operation in ['upload', 'download']

--- a/concent_api/core/transfer_operations.py
+++ b/concent_api/core/transfer_operations.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.utils import timezone
 from golem_messages import message
 from golem_messages import shortcuts
+from golem_messages.message import FileTransferToken
 
 from core import exceptions
 from core.models import Client
@@ -40,7 +41,7 @@ def verify_file_status(
         file_transfer_token     = create_file_transfer_token(
             report_computed_task,
             client_public_key,
-            'upload'
+            FileTransferToken.Operation.upload
         )
         if request_upload_status(file_transfer_token, report_computed_task):
             subtask               = get_task_result
@@ -105,8 +106,8 @@ def store_pending_message(
 def create_file_transfer_token(
     report_computed_task:       message.tasks.ReportComputedTask,
     encoded_client_public_key:  bytes,
-    operation:                  str,
-) -> message.concents.FileTransferToken:
+    operation:                  FileTransferToken.Operation,
+) -> FileTransferToken:
     """
     Function to create FileTransferToken from ReportComputedTask message
     """
@@ -115,26 +116,26 @@ def create_file_transfer_token(
     file_path       = get_storage_file_path(subtask_id, task_id)
 
     assert isinstance(encoded_client_public_key, bytes)
-    assert operation in ['upload', 'download']
-    if operation == 'upload':
+    assert operation in [FileTransferToken.Operation.download, FileTransferToken.Operation.upload]
+    if operation == FileTransferToken.Operation.upload:
         token_expiration_deadline = (
             report_computed_task.task_to_compute.compute_task_def['deadline'] +
             3 * settings.CONCENT_MESSAGING_TIME +
             2 * settings.MAXIMUM_DOWNLOAD_TIME
         )
-    elif operation == 'download':
+    elif operation == FileTransferToken.Operation.download:
         token_expiration_deadline = (
             report_computed_task.task_to_compute.compute_task_def['deadline'] +
             settings.SUBTASK_VERIFICATION_TIME
         )
-    file_transfer_token = message.concents.FileTransferToken(
+    file_transfer_token = FileTransferToken(
         token_expiration_deadline       = token_expiration_deadline,
         storage_cluster_address         = settings.STORAGE_CLUSTER_ADDRESS,
         authorized_client_public_key    = encoded_client_public_key,
         operation                       = operation,
         subtask_id                      = report_computed_task.task_to_compute.compute_task_def['subtask_id']
     )
-    file_transfer_token.files = [message.concents.FileTransferToken.FileInfo()]
+    file_transfer_token.files = [FileTransferToken.FileInfo()]
     file_transfer_token.files[0]['path']      = file_path
     file_transfer_token.files[0]['checksum']  = report_computed_task.package_hash
     file_transfer_token.files[0]['size']      = report_computed_task.size
@@ -145,7 +146,7 @@ def create_file_transfer_token(
 
 
 def request_upload_status(
-    file_transfer_token_from_database:    message.concents.FileTransferToken,
+    file_transfer_token_from_database:    FileTransferToken,
     report_computed_task:                 message.ReportComputedTask
 ) -> bool:
     slash = '/'
@@ -153,11 +154,15 @@ def request_upload_status(
     assert not file_transfer_token_from_database.files[0]['path'].startswith(slash)
     assert settings.STORAGE_CLUSTER_ADDRESS.endswith(slash)
 
-    file_transfer_token = create_file_transfer_token(report_computed_task, settings.CONCENT_PUBLIC_KEY, 'download')
+    file_transfer_token = create_file_transfer_token(
+        report_computed_task,
+        settings.CONCENT_PUBLIC_KEY,
+        FileTransferToken.Operation.download
+    )
 
     assert file_transfer_token.timestamp <= file_transfer_token.token_expiration_deadline  # pylint: disable=no-member
 
-    file_transfer_token.files                 = [message.concents.FileTransferToken.FileInfo()]
+    file_transfer_token.files                 = [FileTransferToken.FileInfo()]
     file_transfer_token.files[0]['path']      = file_transfer_token_from_database.files[0]['path']
     file_transfer_token.files[0]['checksum']  = file_transfer_token_from_database.files[0]['checksum']
     file_transfer_token.files[0]['size']      = file_transfer_token_from_database.files[0]['size']

--- a/concent_api/gatekeeper/tests/test_gatekeeper_views.py
+++ b/concent_api/gatekeeper/tests/test_gatekeeper_views.py
@@ -10,7 +10,8 @@ from django.urls    import reverse
 from golem_messages.shortcuts       import dump
 from golem_messages.message         import FileTransferToken
 
-from utils.helpers                  import get_current_utc_timestamp
+from utils.helpers import get_current_utc_timestamp
+from utils.helpers import get_storage_file_path
 
 
 @override_settings(
@@ -287,7 +288,10 @@ class GatekeeperViewUploadTest(TestCase):
         response = self.client.post(
             '{}{}'.format(
                 reverse('gatekeeper:upload'),
-                'blender/result/1/1.2.zip',
+                get_storage_file_path(
+                    task_id=1,
+                    subtask_id=2,
+                ),
             ),
             HTTP_AUTHORIZATION             = 'Golem D6UAAAAAWoG9YgGsJib/zgj2cAHGXunyxI7t2NYnHKPvrdzVkdT/B58TpQHpdfonuWy8sWq9nrpc9+/1nUTm8O9szLOrFrCPKL7hAQRWLO4JCR6cVGILFbqRKX6abR1AKMLqRUa/ucH5t0YrLe/OPEp6+2swgbRgcnu0dlvfaupn9bwRPZhjVc2hJlDlkz+7aRx+NDEFWQeRHt3q7b8vA0xd/UUvPGudSnzGR6DaM1+Ji4PifQ7AUdYkQHmRNP4yZH+xjCq706J8mftrySj2geoP+TLKZFgpqHhng5I9v0xKpjOnZk9MRTWkzPyxIMwl535ZVLte0J5VRIIaZFEyYFRXgZGVyGinnEIfXZKZdUdRpRELUBK086A/w4aG3shpEPXEzfo42hjdrDEfyx5bZTANyrGwj1hTLKPoVaPMN9wb3MdQ1D1B5Os3+5YdfASnQRZfZmaEJqNAHNlZveLHpA2DcPFNvltcwUy3Jj1gTI43IbbuXNsIXhMKgNaZrNgJKKpQpc+qF9D7CwfugtiD6y/g71UrrUgvVIcZ9UXVTu5OJg2agGiaIvRWrGxfhyzv/HyHR530p7fNTt/dJBCDO55Mx3uhxA/XGYxmz2uk/xIQMR8QU7Cc/tOdvzdHJ+WHhNBo2fe5oLk03AXIhpqOOgJb8nnM',
             content_type                   = 'application/x-www-form-urlencoded',
@@ -301,7 +305,10 @@ class GatekeeperViewUploadTest(TestCase):
 
     def test_upload_should_return_401_if_specific_file_info_data(self):
         file = FileTransferToken.FileInfo(
-            path     = 'blender/result/1/1.2.zip',
+            path     = get_storage_file_path(
+                task_id=1,
+                subtask_id=2
+            ),
             size     = 1,
             checksum = 'sha1:356a192b7913b04c54574d18c28d46e6395428ab\n',
         )
@@ -313,7 +320,10 @@ class GatekeeperViewUploadTest(TestCase):
         response = self.client.post(
             '{}{}'.format(
                 reverse('gatekeeper:upload'),
-                'blender/result/1/1.2.zip',
+                get_storage_file_path(
+                    task_id=1,
+                    subtask_id=2,
+                ),
             ),
             HTTP_AUTHORIZATION             = 'Golem ' + encrypted_token,
             content_type                   = 'application/x-www-form-urlencoded',

--- a/concent_api/gatekeeper/tests/test_gatekeeper_views.py
+++ b/concent_api/gatekeeper/tests/test_gatekeeper_views.py
@@ -34,7 +34,7 @@ class GatekeeperViewUploadTest(TestCase):
         self.upload_token.files[0]['path']      = 'blender/benchmark/test_task/scene-Helicopter-27-cycles.blend'
         self.upload_token.files[0]['checksum']  = 'sha1:95a0f391c7ad86686ab1366bcd519ba5ab3cce89'
         self.upload_token.files[0]['size']      = 1024
-        self.upload_token.operation             = 'upload'
+        self.upload_token.operation             = FileTransferToken.Operation.upload
 
     @freeze_time("2018-12-30 11:00:00")
     def test_upload_should_accept_valid_message(self):
@@ -347,20 +347,20 @@ class GatekeeperViewDownloadTest(TestCase):
     def setUp(self):
         self.message_timestamp  = get_current_utc_timestamp()
         self.public_key         = '85cZzVjahnRpUBwm0zlNnqTdYom1LF1P1WNShLg17cmhN2UssnPrCjHKTi5susO3wrr/q07eswumbL82b4HgOw=='
-        self.upload_token                                 = FileTransferToken()
-        self.upload_token.token_expiration_deadline       = self.message_timestamp + 3600
-        self.upload_token.storage_cluster_address         = 'http://devel.concent.golem.network/'
-        self.upload_token.authorized_client_public_key    = b'\xf3\x97\x19\xcdX\xda\x86tiP\x1c&\xd39M\x9e\xa4\xddb\x89\xb5,]O\xd5cR\x84\xb85\xed\xc9\xa17e,\xb2s\xeb\n1\xcaN.l\xba\xc3\xb7\xc2\xba\xff\xabN\xde\xb3\x0b\xa6l\xbf6o\x81\xe0;'
+        self.download_token                                 = FileTransferToken()
+        self.download_token.token_expiration_deadline       = self.message_timestamp + 3600
+        self.download_token.storage_cluster_address         = 'http://devel.concent.golem.network/'
+        self.download_token.authorized_client_public_key    = b'\xf3\x97\x19\xcdX\xda\x86tiP\x1c&\xd39M\x9e\xa4\xddb\x89\xb5,]O\xd5cR\x84\xb85\xed\xc9\xa17e,\xb2s\xeb\n1\xcaN.l\xba\xc3\xb7\xc2\xba\xff\xabN\xde\xb3\x0b\xa6l\xbf6o\x81\xe0;'
 
-        self.upload_token.files                 = [FileTransferToken.FileInfo()]
-        self.upload_token.files[0]['path']      = 'blender/benchmark/test_task/scene-Helicopter-27-cycles.blend'
-        self.upload_token.files[0]['checksum']  = 'sha1:95a0f391c7ad86686ab1366bcd519ba5ab3cce89'
-        self.upload_token.files[0]['size']      = 1024
-        self.upload_token.operation             = 'download'
+        self.download_token.files                 = [FileTransferToken.FileInfo()]
+        self.download_token.files[0]['path']      = 'blender/benchmark/test_task/scene-Helicopter-27-cycles.blend'
+        self.download_token.files[0]['checksum']  = 'sha1:95a0f391c7ad86686ab1366bcd519ba5ab3cce89'
+        self.download_token.files[0]['size']      = 1024
+        self.download_token.operation             = FileTransferToken.Operation.download
 
     @freeze_time("2018-12-30 11:00:00")
     def test_download_should_accept_valid_message(self):
-        golem_upload_token = dump(self.upload_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
+        golem_upload_token = dump(self.download_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
         encrypted_token = b64encode(golem_upload_token).decode()
         response = self.client.get(
             '{}{}'.format(
@@ -379,7 +379,7 @@ class GatekeeperViewDownloadTest(TestCase):
 
     @freeze_time("2018-12-30 11:00:00")
     def test_download_should_return_401_if_wrong_authorization_header(self):
-        golem_upload_token = dump(self.upload_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
+        golem_upload_token = dump(self.download_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
         encrypted_token = b64encode(golem_upload_token).decode()
         wrong_test_headers = [
             {'HTTP_AUTHORIZATION':      'GolemGolem '+ encrypted_token},
@@ -403,7 +403,7 @@ class GatekeeperViewDownloadTest(TestCase):
 
     @freeze_time("2018-12-30 11:00:00")
     def test_download_should_return_401_if_wrong_token_cluster_address(self):
-        upload_token = self.upload_token
+        upload_token = self.download_token
         upload_token.storage_cluster_address = 'www://storage.concent.golem.network/'
         golem_upload_token = dump(upload_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
         encrypted_token = b64encode(golem_upload_token).decode()
@@ -434,10 +434,10 @@ class GatekeeperViewDownloadTest(TestCase):
             size     = 1024,
         )
 
-        self.upload_token.files = [file1, file2]
+        self.download_token.files = [file1, file2]
         assert file1 == file2
 
-        golem_upload_token = dump(self.upload_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
+        golem_upload_token = dump(self.download_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
         encoded_token = b64encode(golem_upload_token).decode()
         response = self.client.get(
             '{}{}'.format(
@@ -477,10 +477,10 @@ class GatekeeperViewDownloadTest(TestCase):
                 size     = 1024,
             )
 
-            self.upload_token.files = [file1, file2]
-            self.upload_token.sig   = None
+            self.download_token.files = [file1, file2]
+            self.download_token.sig   = None
 
-            golem_upload_token = dump(self.upload_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
+            golem_upload_token = dump(self.download_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
             encrypted_token = b64encode(golem_upload_token).decode()
             response = self.client.get(
                 '{}{}'.format(
@@ -518,10 +518,10 @@ class GatekeeperViewDownloadTest(TestCase):
                 size     = invalid_value,
             )
 
-            self.upload_token.files = [file1, file2]
-            self.upload_token.sig   = None
+            self.download_token.files = [file1, file2]
+            self.download_token.sig   = None
 
-            golem_upload_token = dump(self.upload_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
+            golem_upload_token = dump(self.download_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
             encrypted_token = b64encode(golem_upload_token).decode()
             response = self.client.get(
                 '{}{}'.format(
@@ -552,10 +552,10 @@ class GatekeeperViewDownloadTest(TestCase):
                 size     = 1024,
             )
 
-            self.upload_token.files = [file]
-            self.upload_token.sig   = None
+            self.download_token.files = [file]
+            self.download_token.sig   = None
 
-            golem_upload_token = dump(self.upload_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
+            golem_upload_token = dump(self.download_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
             encrypted_token = b64encode(golem_upload_token).decode()
             response = self.client.get(
                 '{}{}'.format(
@@ -586,10 +586,10 @@ class GatekeeperViewDownloadTest(TestCase):
                 size     = 1024,
             )
 
-            self.upload_token.files = [file]
-            self.upload_token.sig   = None
+            self.download_token.files = [file]
+            self.download_token.sig   = None
 
-            golem_upload_token = dump(self.upload_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
+            golem_upload_token = dump(self.download_token, settings.CONCENT_PRIVATE_KEY, settings.CONCENT_PUBLIC_KEY)
             encrypted_token = b64encode(golem_upload_token).decode()
             response = self.client.get(
                 '{}{}'.format(

--- a/concent_api/gatekeeper/views.py
+++ b/concent_api/gatekeeper/views.py
@@ -149,9 +149,9 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
         return gatekeeper_access_denied_response('authorized_client_public_key is different then Concent-Client-Public-Key header.', path_to_file, loaded_golem_message.subtask_id, client_public_key)
 
     # -OPERATION
-    if request.method == 'POST' and loaded_golem_message.operation != 'upload':
+    if request.method == 'POST' and loaded_golem_message.operation != FileTransferToken.Operation.upload:
         return gatekeeper_access_denied_response('Wrong operation variable for this request method.', path_to_file, loaded_golem_message.subtask_id, client_public_key)
-    if request.method in ['GET', 'HEAD'] and loaded_golem_message.operation != 'download':
+    if request.method in ['GET', 'HEAD'] and loaded_golem_message.operation != FileTransferToken.Operation.download:
         return gatekeeper_access_denied_response('Wrong operation variable for this request method.', path_to_file, loaded_golem_message.subtask_id, client_public_key)
 
     # -FILES

--- a/concent_api/utils/helpers.py
+++ b/concent_api/utils/helpers.py
@@ -148,3 +148,7 @@ def get_validated_client_public_key_from_client_message(golem_message: message.b
         return client_public_key
 
     return None
+
+
+def get_storage_file_path(subtask_id, task_id):
+    return f'blender/result/{task_id}/{task_id}.{subtask_id}.zip'


### PR DESCRIPTION
- use enum instead of strings in creation of `FileTransferToken`
- create and use function for reffering to storage file path