### PR TITLE
Chore refactor api cluster tests: force-accept-or-reject-results

### DIFF
--- a/concent_api/api-integration-force-accept-or-reject-results-test.py
+++ b/concent_api/api-integration-force-accept-or-reject-results-test.py
@@ -15,6 +15,7 @@ from utils.testing_helpers import generate_ecc_key_pair
 
 from api_testing_common import api_request
 from api_testing_common import create_client_auth_message
+from api_testing_common import parse_command_line
 from api_testing_common import timestamp_to_isoformat
 
 from protocol_constants import get_protocol_constants
@@ -25,17 +26,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "concent_api.settings")
 
 (PROVIDER_PRIVATE_KEY,  PROVIDER_PUBLIC_KEY)  = generate_ecc_key_pair()
 (REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY) = generate_ecc_key_pair()
-
-
-def parse_command_line(command_line):
-    if len(command_line) <= 1:
-        sys.exit('Not enough arguments')
-
-    if len(command_line) >= 3:
-        sys.exit('Too many arguments')
-
-    cluster_url = command_line[1]
-    return cluster_url
 
 
 def force_subtask_results(timestamp = None, ack_report_computed_task = None):

--- a/concent_api/api-integration-force-accept-or-reject-results-test.py
+++ b/concent_api/api-integration-force-accept-or-reject-results-test.py
@@ -4,7 +4,6 @@ import os
 import sys
 import random
 import time
-from base64                 import b64encode
 from freezegun              import freeze_time
 
 from golem_messages         import message
@@ -15,6 +14,7 @@ from utils.testing_helpers import generate_ecc_key_pair
 
 from api_testing_common import api_request
 from api_testing_common import create_client_auth_message
+from api_testing_common import get_task_id_and_subtask_id
 from api_testing_common import parse_command_line
 from api_testing_common import timestamp_to_isoformat
 
@@ -100,180 +100,136 @@ def report_computed_task(timestamp = None, task_to_compute = None):
 
 def main():
     cluster_url     = parse_command_line(sys.argv)
-    current_time    = get_current_utc_timestamp()
     cluster_consts  = get_protocol_constants(cluster_url)
-    #  Test CASE 2A + 2D + 3 - Send ForceSubtaskResults with same task_id as stored by Concent before
-    #  Step 1. Send ForceSubtaskResults first time
-    subtask_id = str(random.randrange(1, 100000))
-    task_id = subtask_id + '2A'
+
+    test_id = str(random.randrange(1, 100000))
+    test_case_2a_send_duplicated_force_subtask_results(cluster_consts, cluster_url, test_id)
+
+    test_case_2b_not_enough_funds(cluster_consts, cluster_url, test_id)
+
+    test_case_2c_wrong_timestamps(cluster_consts, cluster_url, test_id)
+
+    test_case_4b_requestor_accepts_subtaks_results(cluster_consts, cluster_url, test_id)
+
+    test_case_2d_requestor_rejects_subtask_results(cluster_consts, cluster_url, test_id)
+
+
+def test_case_2d_requestor_rejects_subtask_results(cluster_consts, cluster_url, id):
+    # Test CASE 2D + 3 + 4B + 5. Requestor sends ForceSubtaskResultsResponse with SubtaskResultsRejected
+    current_time = get_current_utc_timestamp()
+    (subtask_id, task_id) = get_task_id_and_subtask_id(id, '2D')
     api_request(
         cluster_url,
         'send',
         PROVIDER_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
         force_subtask_results(
-            timestamp = timestamp_to_isoformat(current_time),
-            ack_report_computed_task = ack_report_computed_task(
-                timestamp = timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
-                report_computed_task = report_computed_task(
-                    task_to_compute = task_to_compute(
-                        timestamp = timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
-                        compute_task_def = compute_task_def(
-                            task_id     = task_id,
-                            subtask_id  = subtask_id,
-                            deadline    = current_time - (cluster_consts.subtask_verification_time),
+            timestamp=timestamp_to_isoformat(current_time),
+            ack_report_computed_task=ack_report_computed_task(
+                timestamp=timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time)),
+                report_computed_task=report_computed_task(
+                    task_to_compute=task_to_compute(
+                        timestamp=timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
+                        compute_task_def=compute_task_def(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            deadline=current_time - (cluster_consts.subtask_verification_time),
                         )
                     )
                 )
             )
         ),
-        headers = {
-            'Content-Type':                     'application/octet-stream',
-            'temporary-account-funds':          'True'
+        headers={
+            'Content-Type': 'application/octet-stream',
+            'temporary-account-funds': 'True'
         },
         expected_status=202,
     )
-    time.sleep(1)
-    #  Step 2. Send ForceSubtaskResults second time with same task_id
-    api_request(
-        cluster_url,
-        'send',
-        PROVIDER_PRIVATE_KEY,
-        CONCENT_PUBLIC_KEY,
-        force_subtask_results(
-            timestamp = timestamp_to_isoformat(current_time),
-            ack_report_computed_task = ack_report_computed_task(
-                timestamp = timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
-                report_computed_task = report_computed_task(
-                    task_to_compute = task_to_compute(
-                        timestamp = timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
-                        compute_task_def = compute_task_def(
-                            task_id     = task_id,
-                            subtask_id  = subtask_id,
-                            deadline    = current_time - (cluster_consts.subtask_verification_time),
-                        )
-                    )
-                )
-            )
-        ),
-        headers = {
-            'Content-Type':                     'application/octet-stream',
-            'temporary-account-funds':          'True'
-        },
-        expected_status=200,
-        expected_message_type=message.concents.ServiceRefused.TYPE,
-        expected_content_type='application/octet-stream',
-    )
-
-    #  Step 3. Requestor wants to receive ForceSubtaskResults from Concent
     api_request(
         cluster_url,
         'receive',
         REQUESTOR_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
         create_client_auth_message(REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY, CONCENT_PUBLIC_KEY),
-        headers = {
+        headers={
             'Content-Type': 'application/octet-stream',
         },
         expected_status=200,
         expected_message_type=message.concents.ForceSubtaskResults.TYPE,
         expected_content_type='application/octet-stream',
     )
-
-    #  Test CASE 2B - Send ForceSubtaskResults with not enough amount of funds on account
-    subtask_id = str(random.randrange(1, 100000))
-    task_id = subtask_id + '2B'
     api_request(
         cluster_url,
         'send',
-        PROVIDER_PRIVATE_KEY,
+        REQUESTOR_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
-        force_subtask_results(
-            timestamp = timestamp_to_isoformat(current_time),  # current_time
-            ack_report_computed_task = ack_report_computed_task(
-                timestamp = timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
-                report_computed_task = report_computed_task(
-                    task_to_compute = task_to_compute(
-                        timestamp = timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
-                        compute_task_def = compute_task_def(
-                            task_id     = task_id,
-                            subtask_id  = subtask_id,
-                            deadline    = current_time - (cluster_consts.subtask_verification_time),
+        force_subtask_results_response(
+            timestamp=timestamp_to_isoformat(current_time),
+            subtask_results_rejected=subtask_results_rejected(
+                timestamp=timestamp_to_isoformat(current_time),
+                report_computed_task=report_computed_task(
+                    timestamp=timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time)),
+                    task_to_compute=task_to_compute(
+                        timestamp=timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
+                        compute_task_def=compute_task_def(
+                            deadline=current_time - (cluster_consts.subtask_verification_time),
+                            task_id=task_id,
+                            subtask_id=subtask_id,
                         )
                     )
                 )
             )
         ),
-        headers = {
-            'Content-Type':                     'application/octet-stream',
-            'temporary-account-funds':          ''
+        headers={
+            'Content-Type': 'application/octet-stream',
+            'temporary-account-funds': 'True'
         },
-        expected_status=200,
-        expected_message_type=message.concents.ServiceRefused.TYPE,
-        expected_content_type='application/octet-stream',
+        expected_status=202,
     )
-
-    # Test CASE 2C - Send ForceSubtaskResults with wrong timestamps
-    subtask_id = str(random.randrange(1, 100000))
-    task_id = subtask_id + '2C'
     api_request(
         cluster_url,
-        'send',
+        'receive',
         PROVIDER_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
-        force_subtask_results(
-            timestamp = timestamp_to_isoformat(current_time),
-            ack_report_computed_task =ack_report_computed_task(
-                timestamp = timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
-                report_computed_task = report_computed_task(
-                    task_to_compute = task_to_compute(
-                        timestamp = timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
-                        compute_task_def = compute_task_def(
-                            task_id     = task_id,
-                            subtask_id  = subtask_id,
-                            deadline    = current_time - (cluster_consts.subtask_verification_time * 20),
-                        )
-                    )
-                )
-            )
-        ),
-        headers = {
-            'Content-Type':                     'application/octet-stream',
-            'temporary-account-funds':          'True'
+        create_client_auth_message(PROVIDER_PRIVATE_KEY, PROVIDER_PUBLIC_KEY, CONCENT_PUBLIC_KEY),
+        headers={
+            'Content-Type': 'application/octet-stream',
         },
         expected_status=200,
-        expected_message_type=message.concents.ForceSubtaskResultsRejected.TYPE,
+        expected_message_type=message.concents.ForceSubtaskResultsResponse.TYPE,
         expected_content_type='application/octet-stream',
     )
 
+
+def test_case_4b_requestor_accepts_subtaks_results(cluster_consts, cluster_url, test_id):
     # Test CASE 4B + 5. Requestor sends ForceSubtaskResultsResponse with SubtaskResultsAccepted
     #  Step 1. Send ForceSubtaskResults
-    subtask_id = str(random.randrange(1, 100000))
-    task_id = subtask_id + '4B'
+    current_time = get_current_utc_timestamp()
+    (task_id, subtask_id) = get_task_id_and_subtask_id(test_id, '4B')
     api_request(
         cluster_url,
         'send',
         PROVIDER_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
         force_subtask_results(
-            timestamp = timestamp_to_isoformat(current_time),
-            ack_report_computed_task = ack_report_computed_task(
-                timestamp = timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
-                report_computed_task = report_computed_task(
-                    task_to_compute = task_to_compute(
-                        timestamp = timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
-                        compute_task_def = compute_task_def(
-                            task_id     = task_id,
-                            subtask_id  = subtask_id,
-                            deadline    = current_time - (cluster_consts.subtask_verification_time),
+            timestamp=timestamp_to_isoformat(current_time),
+            ack_report_computed_task=ack_report_computed_task(
+                timestamp=timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
+                report_computed_task=report_computed_task(
+                    task_to_compute=task_to_compute(
+                        timestamp=timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
+                        compute_task_def=compute_task_def(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            deadline=current_time - (cluster_consts.subtask_verification_time),
                         )
                     )
                 )
             )
         ),
-        headers = {
-            'Content-Type':                     'application/octet-stream',
-            'temporary-account-funds':          'True'
+        headers={
+            'Content-Type': 'application/octet-stream',
+            'temporary-account-funds': 'True'
         },
         expected_status=202,
     )
@@ -285,35 +241,33 @@ def main():
         REQUESTOR_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
         force_subtask_results_response(
-            timestamp = timestamp_to_isoformat(current_time),
-            subtask_results_accepted = subtask_results_accepted(
-                timestamp = timestamp_to_isoformat(current_time),
-                payment_ts = timestamp_to_isoformat(current_time + 1),
-                task_to_compute = task_to_compute(
-                    timestamp = timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
-                    compute_task_def = compute_task_def(
-                        task_id = task_id,
-                        subtask_id = subtask_id,
-                        deadline = current_time - (cluster_consts.subtask_verification_time),
-
+            timestamp=timestamp_to_isoformat(current_time),
+            subtask_results_accepted=subtask_results_accepted(
+                timestamp=timestamp_to_isoformat(current_time),
+                payment_ts=timestamp_to_isoformat(current_time + 1),
+                task_to_compute=task_to_compute(
+                    timestamp=timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
+                    compute_task_def=compute_task_def(
+                        task_id=task_id,
+                        subtask_id=subtask_id,
+                        deadline=current_time - (cluster_consts.subtask_verification_time),
                     )
                 )
             )
         ),
-        headers = {
-            'Content-Type':                 'application/octet-stream',
-            'temporary-account-funds':      'True'
+        headers={
+            'Content-Type': 'application/octet-stream',
+            'temporary-account-funds': 'True'
         },
         expected_status=202,
     )
-
     api_request(
         cluster_url,
         'receive',
         PROVIDER_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
         create_client_auth_message(PROVIDER_PRIVATE_KEY, PROVIDER_PUBLIC_KEY, CONCENT_PUBLIC_KEY),
-        headers = {
+        headers={
             'Content-Type': 'application/octet-stream',
         },
         expected_status=200,
@@ -321,92 +275,152 @@ def main():
         expected_content_type='application/octet-stream',
     )
 
-    # Test CASE 2D + 3 + 4B + 5. Requestor sends ForceSubtaskResultsResponse with SubtaskResultsRejected
-    subtask_id = str(random.randrange(1, 100000))
-    task_id = subtask_id + '2D'
+
+def test_case_2c_wrong_timestamps(cluster_consts, cluster_url, test_id):
+    # Test CASE 2C - Send ForceSubtaskResults with wrong timestamps
+    current_time = get_current_utc_timestamp()
+    (task_id, subtask_id) = get_task_id_and_subtask_id(test_id, '2C')
     api_request(
         cluster_url,
         'send',
         PROVIDER_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
         force_subtask_results(
-            timestamp = timestamp_to_isoformat(current_time),
-            ack_report_computed_task = ack_report_computed_task(
-                timestamp = timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time)),
-                report_computed_task = report_computed_task(
-                    task_to_compute = task_to_compute(
-                        timestamp = timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
-                        compute_task_def = compute_task_def(
-                            task_id     = task_id,
-                            subtask_id  = subtask_id,
-                            deadline    = current_time - (cluster_consts.subtask_verification_time),
+            timestamp=timestamp_to_isoformat(current_time),
+            ack_report_computed_task=ack_report_computed_task(
+                timestamp=timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
+                report_computed_task=report_computed_task(
+                    task_to_compute=task_to_compute(
+                        timestamp=timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
+                        compute_task_def=compute_task_def(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            deadline=current_time - (cluster_consts.subtask_verification_time * 20),
                         )
                     )
                 )
             )
         ),
-        headers = {
-            'Content-Type':                     'application/octet-stream',
-            'temporary-account-funds':          'True'
+        headers={
+            'Content-Type': 'application/octet-stream',
+            'temporary-account-funds': 'True'
+        },
+        expected_status=200,
+        expected_message_type=message.concents.ForceSubtaskResultsRejected.TYPE,
+        expected_content_type='application/octet-stream',
+    )
+
+
+def test_case_2b_not_enough_funds(cluster_consts, cluster_url, test_id):
+    #  Test CASE 2B - Send ForceSubtaskResults with not enough amount of funds on account
+    current_time = get_current_utc_timestamp()
+    (task_id, subtask_id) = get_task_id_and_subtask_id(test_id, '2B')
+    api_request(
+        cluster_url,
+        'send',
+        PROVIDER_PRIVATE_KEY,
+        CONCENT_PUBLIC_KEY,
+        force_subtask_results(
+            timestamp=timestamp_to_isoformat(current_time),  # current_time
+            ack_report_computed_task=ack_report_computed_task(
+                timestamp=timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
+                report_computed_task=report_computed_task(
+                    task_to_compute=task_to_compute(
+                        timestamp=timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
+                        compute_task_def=compute_task_def(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            deadline=current_time - (cluster_consts.subtask_verification_time),
+                        )
+                    )
+                )
+            )
+        ),
+        headers={
+            'Content-Type': 'application/octet-stream',
+            'temporary-account-funds': ''
+        },
+        expected_status=200,
+        expected_message_type=message.concents.ServiceRefused.TYPE,
+        expected_content_type='application/octet-stream',
+    )
+
+
+def test_case_2a_send_duplicated_force_subtask_results(cluster_consts, cluster_url, test_id):
+    #  Test CASE 2A + 2D + 3 - Send ForceSubtaskResults with same task_id as stored by Concent before
+    #  Step 1. Send ForceSubtaskResults first time
+    current_time = get_current_utc_timestamp()
+    (task_id, subtask_id) = get_task_id_and_subtask_id(test_id, '2A')
+    api_request(
+        cluster_url,
+        'send',
+        PROVIDER_PRIVATE_KEY,
+        CONCENT_PUBLIC_KEY,
+        force_subtask_results(
+            timestamp=timestamp_to_isoformat(current_time),
+            ack_report_computed_task=ack_report_computed_task(
+                timestamp=timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
+                report_computed_task=report_computed_task(
+                    task_to_compute=task_to_compute(
+                        timestamp=timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
+                        compute_task_def=compute_task_def(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            deadline=current_time - (cluster_consts.subtask_verification_time),
+                        )
+                    )
+                )
+            )
+        ),
+        headers={
+            'Content-Type': 'application/octet-stream',
+            'temporary-account-funds': 'True'
         },
         expected_status=202,
     )
-
+    time.sleep(1)
+    #  Step 2. Send ForceSubtaskResults second time with same task_id
+    api_request(
+        cluster_url,
+        'send',
+        PROVIDER_PRIVATE_KEY,
+        CONCENT_PUBLIC_KEY,
+        force_subtask_results(
+            timestamp=timestamp_to_isoformat(current_time),
+            ack_report_computed_task=ack_report_computed_task(
+                timestamp=timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time * 1.4)),
+                report_computed_task=report_computed_task(
+                    task_to_compute=task_to_compute(
+                        timestamp=timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
+                        compute_task_def=compute_task_def(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            deadline=current_time - (cluster_consts.subtask_verification_time),
+                        )
+                    )
+                )
+            )
+        ),
+        headers={
+            'Content-Type': 'application/octet-stream',
+            'temporary-account-funds': 'True'
+        },
+        expected_status=200,
+        expected_message_type=message.concents.ServiceRefused.TYPE,
+        expected_content_type='application/octet-stream',
+    )
+    #  Step 3. Requestor wants to receive ForceSubtaskResults from Concent
     api_request(
         cluster_url,
         'receive',
         REQUESTOR_PRIVATE_KEY,
         CONCENT_PUBLIC_KEY,
         create_client_auth_message(REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY, CONCENT_PUBLIC_KEY),
-        headers = {
+        headers={
             'Content-Type': 'application/octet-stream',
         },
         expected_status=200,
         expected_message_type=message.concents.ForceSubtaskResults.TYPE,
-        expected_content_type='application/octet-stream',
-    )
-
-    api_request(
-        cluster_url,
-        'send',
-        REQUESTOR_PRIVATE_KEY,
-        CONCENT_PUBLIC_KEY,
-        force_subtask_results_response(
-            timestamp = timestamp_to_isoformat(current_time),
-            subtask_results_rejected = subtask_results_rejected(
-                timestamp = timestamp_to_isoformat(current_time),
-                report_computed_task = report_computed_task(
-                    timestamp = timestamp_to_isoformat(current_time - (cluster_consts.subtask_verification_time)),
-                    task_to_compute = task_to_compute(
-                        timestamp = timestamp_to_isoformat(current_time - cluster_consts.subtask_verification_time * 1.5),
-                        compute_task_def = compute_task_def(
-                            deadline    = current_time - (cluster_consts.subtask_verification_time),
-                            task_id     = task_id,
-                            subtask_id  = subtask_id,
-                        )
-                    )
-                )
-            )
-        ),
-        headers = {
-            'Content-Type':                 'application/octet-stream',
-            'temporary-account-funds':      'True'
-        },
-        expected_status=202,
-    )
-
-    api_request(
-        cluster_url,
-        'receive',
-        PROVIDER_PRIVATE_KEY,
-        CONCENT_PUBLIC_KEY,
-        create_client_auth_message(PROVIDER_PRIVATE_KEY, PROVIDER_PUBLIC_KEY, CONCENT_PUBLIC_KEY),
-        headers = {
-            'Content-Type':                     'application/octet-stream',
-            'concent-other-party-public-key':   b64encode(REQUESTOR_PUBLIC_KEY).decode('ascii'),
-        },
-        expected_status=200,
-        expected_message_type=message.concents.ForceSubtaskResultsResponse.TYPE,
         expected_content_type='application/octet-stream',
     )
 

--- a/concent_api/api-integration-force-get-task-result-test.py
+++ b/concent_api/api-integration-force-get-task-result-test.py
@@ -17,6 +17,7 @@ from utils.testing_helpers import generate_ecc_key_pair
 
 from api_testing_common import api_request
 from api_testing_common import create_client_auth_message
+from api_testing_common import parse_command_line
 from api_testing_common import timestamp_to_isoformat
 
 from freezegun import freeze_time
@@ -29,17 +30,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "concent_api.settings")
 
 (PROVIDER_PRIVATE_KEY,  PROVIDER_PUBLIC_KEY)  = generate_ecc_key_pair()
 (REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY) = generate_ecc_key_pair()
-
-
-def parse_command_line(command_line):
-    if len(command_line) <= 1:
-        sys.exit('Not enough arguments')
-
-    if len(command_line) >= 3:
-        sys.exit('Too many arguments')
-
-    cluster_url = command_line[1]
-    return cluster_url
 
 
 def upload_new_file_on_cluster(task_id, subtask_id, cluster_consts, current_time):

--- a/concent_api/api-integration-force-payment.py
+++ b/concent_api/api-integration-force-payment.py
@@ -15,6 +15,7 @@ from utils.testing_helpers import generate_ecc_key_pair
 
 from api_testing_common import api_request
 from api_testing_common import create_client_auth_message
+from api_testing_common import parse_command_line
 from api_testing_common import timestamp_to_isoformat
 
 from protocol_constants import get_protocol_constants
@@ -27,17 +28,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "concent_api.settings")
 (REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY) = generate_ecc_key_pair()
 (DIFFERENT_PROVIDER_PRIVATE_KEY, DIFFERENT_PROVIDER_PUBLIC_KEY)     = generate_ecc_key_pair()
 (DIFFERENT_REQUESTOR_PRIVATE_KEY, DIFFERENT_REQUESTOR_PUBLIC_KEY)   = generate_ecc_key_pair()
-
-
-def parse_command_line(command_line):
-    if len(command_line) <= 1:
-        sys.exit('Not enough arguments')
-
-    if len(command_line) >= 3:
-        sys.exit('Too many arguments')
-
-    cluster_url = command_line[1]
-    return cluster_url
 
 
 def force_payment(timestamp = None, subtask_results_accepted_list = None):

--- a/concent_api/api-integration-force-report-computed-task-test.py
+++ b/concent_api/api-integration-force-report-computed-task-test.py
@@ -40,9 +40,9 @@ def parse_command_line(command_line):
 
 
 def create_signed_task_to_compute(
-    task_id=None,
-    subtask_id=None,
-    deadline=None,
+    task_id,
+    subtask_id,
+    deadline,
     provider_public_key=None,
     requestor_public_key=None
 ):

--- a/concent_api/api-integration-force-report-computed-task-test.py
+++ b/concent_api/api-integration-force-report-computed-task-test.py
@@ -15,7 +15,7 @@ from utils.helpers import get_current_utc_timestamp
 from utils.helpers import sign_message
 from utils.testing_helpers import generate_ecc_key_pair
 
-from api_testing_common import api_request
+from api_testing_common import api_request, parse_command_line
 from api_testing_common import create_client_auth_message
 
 from protocol_constants import get_protocol_constants
@@ -26,17 +26,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "concent_api.settings")
 
 (PROVIDER_PRIVATE_KEY,  PROVIDER_PUBLIC_KEY)  = generate_ecc_key_pair()
 (REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY) = generate_ecc_key_pair()
-
-
-def parse_command_line(command_line):
-    if len(command_line) <= 1:
-        sys.exit('Not enough arguments')
-
-    if len(command_line) >= 3:
-        sys.exit('Too many arguments')
-
-    cluster_url = command_line[1]
-    return cluster_url
 
 
 def create_signed_task_to_compute(

--- a/concent_api/api_testing_common.py
+++ b/concent_api/api_testing_common.py
@@ -16,6 +16,38 @@ class TestAssertionException(Exception):
     pass
 
 
+class count_fails(object):
+    """
+    Decorator that wraps a test functions for intercepting assertions and counting them.
+    """
+    instances = []
+    number_of_run_tests = 0
+
+    def __init__(self, function):
+        self._function     = function
+        self.__name__ = function.__name__
+        self.failed  = False
+        count_fails.instances.append(self)
+
+    def __call__(self, *args, **kwargs):
+        try:
+            print("Running TC: " + self.__name__)
+            count_fails.number_of_run_tests += 1
+            return self._function(*args, **kwargs)
+        except TestAssertionException as exception:
+            print("{}: FAILED".format(self.__name__))
+            print(exception)
+            self.failed = True
+
+    @classmethod
+    def get_fails(cls):
+        return sum([instance.failed for instance in cls.instances])
+
+    @classmethod
+    def print_fails(cls):
+        print(f'Total failed tests : {cls.get_fails()} out of {cls.number_of_run_tests}')
+
+
 def assert_condition(actual, expected, error_message = None):
     message = error_message or f"Actual: {actual} != expected: {expected}"
     if actual != expected:

--- a/concent_api/api_testing_common.py
+++ b/concent_api/api_testing_common.py
@@ -214,3 +214,9 @@ def parse_command_line(command_line):
 
 if __name__ == '__main__':
     pass
+
+
+def get_task_id_and_subtask_id(test_id, case_name):
+    task_id = f'task_{case_name}_{test_id}'
+    subtask_id = 'sub_' + task_id
+    return (subtask_id, task_id)

--- a/concent_api/api_testing_common.py
+++ b/concent_api/api_testing_common.py
@@ -1,3 +1,5 @@
+import sys
+
 from golem_messages.exceptions      import MessageError
 from golem_messages.message         import Message
 from golem_messages.message.concents import ClientAuthorization
@@ -168,6 +170,17 @@ def create_client_auth_message(client_priv_key, client_public_key, concent_publi
     client_auth = ClientAuthorization()
     client_auth.client_public_key = client_public_key
     return dump(client_auth, client_priv_key, concent_public_key)
+
+
+def parse_command_line(command_line):
+    if len(command_line) <= 1:
+        sys.exit('Not enough arguments')
+
+    if len(command_line) >= 3:
+        sys.exit('Too many arguments')
+
+    cluster_url = command_line[1]
+    return cluster_url
 
 
 if __name__ == '__main__':

--- a/concent_api/api_testing_common.py
+++ b/concent_api/api_testing_common.py
@@ -100,17 +100,14 @@ def api_request(
     assert all(value not in ['', None] for value in [endpoint, host, headers])
     url = "{}/api/v1/{}/".format(host, endpoint)
 
-    if endpoint == 'send':
-        _print_data(data, url)
-        response = requests.post("{}".format(url), headers=headers, data=_prepare_data(data), verify=False)
-    else:
-        print('RECEIVE ({})'.format(url))
-        response = requests.post("{}".format(url), headers=headers, data=data, verify=False)
+    _print_data(data, url)
+    response = requests.post("{}".format(url), headers=headers, data=_prepare_data(data), verify=False)
     _print_response(private_key, public_key, response)
     validate_response_status(response.status_code, expected_status)
     validate_content_type(response.headers['Content-Type'], expected_content_type)
     validate_response_message(response.content, expected_message_type, private_key, public_key)
     print()
+    return response
 
 
 def _print_response(private_key, public_key, response):


### PR DESCRIPTION
This is (almost) final version of `force-accept-or-reject-results` - once other tests are brought to similiar level, further refactoring is possible (extracing more common items, reusing helper method/functions form django integration tests)