### PR TITLE
Add error handling middleware

### DIFF
--- a/concent_api/concent_api/constants.py
+++ b/concent_api/concent_api/constants.py
@@ -56,3 +56,4 @@ APP_LABEL_TO_DATABASE = {
     'database':     'default',
     'sessions':     'default',
 }
+DEFAULT_ERROR_MESSAGE = "Something went wrong, sorry"

--- a/concent_api/concent_api/middleware.py
+++ b/concent_api/concent_api/middleware.py
@@ -1,8 +1,13 @@
 import os
+import traceback
 
 from django.conf    import settings
+from django.db import transaction
+from django.http import JsonResponse
 
 from golem_messages import __version__
+from concent_api.constants import DEFAULT_ERROR_MESSAGE
+from utils.constants import ErrorCode
 
 
 class GolemMessagesVersionMiddleware(object):
@@ -39,3 +44,33 @@ class ConcentVersionMiddleware(object):
         response = self.get_response(request)
         response['Concent-Version'] = self._concent_version
         return response
+
+
+class HandleServerErrorMiddleware(object):
+    """
+    Used to catch all unhandled exceptions and return JSON response containing error information.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.sid = None
+
+    def __call__(self, request):
+        self.sid = transaction.savepoint()
+        response = self.get_response(request)
+        transaction.savepoint_commit(self.sid)
+        return response
+
+    def process_exception(self, request, exception):  # pylint: disable=unused-argument
+        transaction.savepoint_rollback(self.sid)
+        return self._build_json_response(exception)
+
+    @staticmethod
+    def _build_json_response(exception):
+        message = {
+            "error_message": str(exception) or DEFAULT_ERROR_MESSAGE,
+            "error_code": getattr(exception, "error_code", ErrorCode.CONCENT_APPLICATION_CRASH.value),
+        }
+        debug_info = getattr(settings, 'DEBUG_INFO_IN_ERROR_RESPONSES', settings.DEBUG)
+        if debug_info:
+            message["stack_trace"] = traceback.format_exc()
+        return JsonResponse(message, status=500)

--- a/concent_api/concent_api/settings/base.py
+++ b/concent_api/concent_api/settings/base.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'concent_api.middleware.HandleServerErrorMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -291,3 +292,6 @@ CONCENT_FEATURES = []  # type: ignore
 
 # URL format: 'protocol://<user>:<password>@<hostname>:<port>/<virtual host>'
 # CELERY_BROKER_URL = ''
+
+# Debug setting for adding stack traces in HTTP500 responses
+# DEBUG_INFO_IN_ERROR_RESPONSES = ''

--- a/concent_api/concent_api/settings/development.py
+++ b/concent_api/concent_api/settings/development.py
@@ -4,6 +4,7 @@ from .base import *  # NOQA  # pylint: disable=wildcard-import
 SECRET_KEY = 'testkey'
 
 DEBUG = True
+DEBUG_INFO_IN_ERROR_RESPONSES = True
 
 DATABASES['default']['USER']     = 'postgres'
 DATABASES['default']['PASSWORD'] = ''

--- a/concent_api/concent_api/tests/test_middleware.py
+++ b/concent_api/concent_api/tests/test_middleware.py
@@ -1,17 +1,39 @@
+import json
+
 import mock
 
 from django.test            import override_settings
 from django.test            import TestCase
 from django.urls            import reverse
+
 from golem_messages         import dump
 from golem_messages         import message
 from golem_messages         import __version__
 
-from utils.testing_helpers  import generate_ecc_key_pair
+from concent_api.constants import DEFAULT_ERROR_MESSAGE
+from core.tests.utils import ConcentIntegrationTestCase
+from utils.constants import ErrorCode
+from utils.testing_helpers import generate_ecc_key_pair
 
 
 (CONCENT_PRIVATE_KEY,   CONCENT_PUBLIC_KEY)   = generate_ecc_key_pair()
 (PROVIDER_PRIVATE_KEY,  PROVIDER_PUBLIC_KEY)  = generate_ecc_key_pair()
+
+
+class CustomException(Exception):
+    pass
+
+
+class CustomExceptionWithStringRepr(Exception):
+    def __init__(self, error_message):
+        super().__init__()
+        self.message = error_message
+
+    def __repr__(self):
+        return self.message
+
+    def __str__(self):
+        return self.message
 
 
 @override_settings(
@@ -81,3 +103,111 @@ class ConcentVersionMiddlewareTest(TestCase):
             response._headers['concent-version'][1],
             '1.0'
         )
+
+
+@override_settings(
+    CONCENT_PRIVATE_KEY=CONCENT_PRIVATE_KEY,
+    CONCENT_PUBLIC_KEY=CONCENT_PUBLIC_KEY,
+    DEBUG=False,
+)
+class HandleServerErrorMiddlewareTest(ConcentIntegrationTestCase):
+    def test_that_middlware_does_not_intercept_2xx_http_responses(self):
+        response = self.client.post(
+            reverse('core:receive'),
+            data=self._create_client_auth_message(PROVIDER_PRIVATE_KEY, PROVIDER_PUBLIC_KEY),
+            content_type='application/octet-stream',
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_that_middleware_does_not_intercept_bad_requests(self):
+        ping_message = message.Ping()
+        serialized_ping_message = dump(ping_message, PROVIDER_PRIVATE_KEY, CONCENT_PUBLIC_KEY)
+        response = self.client.post(
+            reverse('core:receive'),
+            data=serialized_ping_message,
+            content_type='application/octet-stream',
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_that_uncaught_errors_without_string_representation_are_returned_as_json_response_with_status_500_and_default_error_message(self):
+        with mock.patch('core.views.handle_messages_from_database', side_effect=CustomException(), autospec=True):
+            response = self.client.post(
+                reverse('core:receive'),
+                data=self._create_client_auth_message(PROVIDER_PRIVATE_KEY, PROVIDER_PUBLIC_KEY),
+                content_type='application/octet-stream',
+            )
+            loaded_json = json.loads(response.content)
+            self._assert_proper_internal_server_error_received(
+                response,
+                loaded_json,
+                DEFAULT_ERROR_MESSAGE,
+                ErrorCode.CONCENT_APPLICATION_CRASH.value
+            )
+
+    def test_that_uncaught_errors_with_string_representation_are_returned_as_json_response_with_status_500(self):
+        error_message = "I am sorry, it's all my fault"
+        with mock.patch(
+            'core.views.handle_messages_from_database',
+            side_effect=CustomExceptionWithStringRepr(error_message),
+            autospec=True
+        ):
+            response = self.client.post(
+                reverse('core:receive'),
+                data=self._create_client_auth_message(PROVIDER_PRIVATE_KEY, PROVIDER_PUBLIC_KEY),
+                content_type='application/octet-stream',
+            )
+            loaded_json = json.loads(response.content)
+            self._assert_proper_internal_server_error_received(
+                response,
+                loaded_json,
+                error_message,
+                ErrorCode.CONCENT_APPLICATION_CRASH.value
+            )
+
+    @override_settings(
+        DEBUG=True,
+    )
+    def test_that_with_debug_enabled_uncaught_errors_are_returned_as_json_response_with_status_500_and_stack_trace(
+        self
+    ):
+        with mock.patch('core.views.handle_messages_from_database', side_effect=CustomException(), autospec=True):
+            response = self.client.post(
+                reverse('core:receive'),
+                data=self._create_client_auth_message(PROVIDER_PRIVATE_KEY, PROVIDER_PUBLIC_KEY),
+                content_type='application/octet-stream',
+            )
+            loaded_json = json.loads(response.content)
+            self._assert_proper_internal_server_error_received(
+                response,
+                loaded_json,
+                DEFAULT_ERROR_MESSAGE,
+                ErrorCode.CONCENT_APPLICATION_CRASH.value
+            )
+            self.assertIn('stack_trace', loaded_json)
+            self.assertTrue(len(loaded_json['stack_trace']) > 0)
+
+    @override_settings(
+        DEBUG_INFO_IN_ERROR_RESPONSES=True,
+    )
+    def test_that_with_debug_info_enabled_uncaught_errors_are_returned_as_json_response_with_status_500_and_stack_trace(self):
+        with mock.patch('core.views.handle_messages_from_database', side_effect=CustomException(), autospec=True):
+            response = self.client.post(
+                reverse('core:receive'),
+                data=self._create_client_auth_message(PROVIDER_PRIVATE_KEY, PROVIDER_PUBLIC_KEY),
+                content_type='application/octet-stream',
+            )
+            loaded_json = json.loads(response.content)
+            self._assert_proper_internal_server_error_received(
+                response,
+                loaded_json,
+                DEFAULT_ERROR_MESSAGE,
+                ErrorCode.CONCENT_APPLICATION_CRASH.value
+            )
+            self.assertIn('stack_trace', loaded_json)
+            self.assertTrue(len(loaded_json['stack_trace']) > 0)
+
+    def _assert_proper_internal_server_error_received(self, response, loaded_json, error_message, error_code):
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('error_message', loaded_json)
+        self.assertEqual(loaded_json['error_message'], error_message)
+        self.assertEqual(loaded_json['error_code'], error_code)

--- a/concent_api/utils/constants.py
+++ b/concent_api/utils/constants.py
@@ -5,6 +5,7 @@ class ErrorCode(enum.Enum):
     REQUEST_BODY_NOT_EMPTY                                              = 'request_body.not_empty'
     AUTH_CLIENT_AUTH_MESSAGE_MISSING                                    = 'header.client_public_key.missing'
     AUTH_CLIENT_AUTH_MESSAGE_INVALID                                    = 'header.client_public_key.invalid'
+    CONCENT_APPLICATION_CRASH                                           = 'concent.application_crash'
     HEADER_AUTHORIZATION_MISSING                                        = 'header.authorization.missing'
     HEADER_AUTHORIZATION_MISSING_TOKEN                                  = 'header.authorization.missing_token'
     HEADER_AUTHORIZATION_TOKEN_INVALID_MESSAGE                          = 'header.authorization.token_not_valid_message'


### PR DESCRIPTION
- Exceptions not caught in views are intercepted and transformed to JsonResponse with status=500 and error details
resolves: https://github.com/golemfactory/concent/issues/57