### PR TITLE
Add and update logging in gatekeeper. 

### DIFF
--- a/concent_api/gatekeeper/tests/test_utils.py
+++ b/concent_api/gatekeeper/tests/test_utils.py
@@ -3,6 +3,7 @@ import json
 
 from django.http                    import JsonResponse
 from django.test                    import TestCase
+from golem_messages.message         import FileTransferToken
 
 from gatekeeper.utils               import gatekeeper_access_denied_response
 from utils.constants                import ErrorCode
@@ -19,6 +20,7 @@ class GatekeeperAccessDeniedResponseTest(TestCase):
     def test_gatekeeper_access_denied_response_should_return_appropriate_body_and_headers(self):
         response = gatekeeper_access_denied_response(
             self.message,
+            FileTransferToken.Operation.upload,
             ErrorCode.HEADER_AUTHORIZATION_MISSING,
             self.path,
             None,

--- a/concent_api/gatekeeper/utils.py
+++ b/concent_api/gatekeeper/utils.py
@@ -1,16 +1,35 @@
 from django.http import JsonResponse
+from golem_messages.message import FileTransferToken
+
+from utils import logging
 
 
-def gatekeeper_access_denied_response(message, error_code = None, path = None, subtask_id = None, client_key = None):
+def gatekeeper_access_denied_response(
+    message: str,
+    operation: FileTransferToken.Operation,
+    error_code=None,
+    path=None,
+    subtask_id=None,
+    client_key=None
+):
     data = {
-        'message':         message,
-        'error_code':      error_code.value,
-        'path_to_file':    path,
-        'subtask_id':      subtask_id,
-        'client_key':      client_key,
+        'message': message,
+        'error_code': error_code.value,
+        'path_to_file': path,
+        'subtask_id': subtask_id,
+        'client_key': client_key,
     }
 
+    logging.log_operation_validation_failed(
+        operation.capitalize(),
+        message,
+        error_code.value,
+        path,
+        subtask_id,
+        client_key
+    )
+
     # The status code here must be always 401 because auth_request module in nginx can only handle HTTP 401.
-    response                     = JsonResponse(data, status = 401)
+    response = JsonResponse(data, status=401)
     response["WWW-Authenticate"] = 'Golem realm="Concent Storage"'
     return response

--- a/concent_api/gatekeeper/views.py
+++ b/concent_api/gatekeeper/views.py
@@ -1,8 +1,6 @@
 import binascii
 from base64                         import b64decode
 from base64                         import b64encode
-import json
-import logging
 import re
 from typing                         import Union
 
@@ -23,11 +21,10 @@ from golem_messages.shortcuts       import load
 
 from gatekeeper.enums               import HashingAlgorithm
 from gatekeeper.utils               import gatekeeper_access_denied_response
+from utils                          import logging
 from utils.constants                import ErrorCode
 from utils.helpers                  import get_current_utc_timestamp
 
-
-logger = logging.getLogger(__name__)
 
 VALID_SHA1_HASH_REGEX = re.compile(r"^[a-fA-F\d]{40}$")
 
@@ -35,22 +32,26 @@ VALID_SHA1_HASH_REGEX = re.compile(r"^[a-fA-F\d]{40}$")
 @csrf_exempt
 @require_POST
 def upload(request):
-    logger.debug("Upload request received.")
+    logging.log_request_received(
+        request.META['PATH_INFO'] if 'PATH_INFO' in request.META.keys() else '-path to file UNAVAILABLE-',
+        FileTransferToken.Operation.upload
+    )
 
     if request.content_type in ['multipart/form-data', '', None] or request.content_type.isspace():
-        logger.info(f'Unsupported content type: {request.content_type}')
         return gatekeeper_access_denied_response(
             'Unsupported content type.',
+            FileTransferToken.Operation.upload,
             ErrorCode.HEADER_CONTENT_TYPE_NOT_SUPPORTED,
+            request.META['PATH_INFO'] if 'PATH_INFO' in request.META.keys() else 'UNAVAILABLE'
         )
 
     path_to_file = request.get_full_path().partition(reverse('gatekeeper:upload'))[2]
-    response_or_file_info = parse_headers(request, path_to_file)
+    response_or_file_info = parse_headers(request, path_to_file, FileTransferToken.Operation.upload)
+
     if not isinstance(response_or_file_info, FileTransferToken.FileInfo):
         assert isinstance(response_or_file_info, JsonResponse)
-        logger.info(json.loads(response_or_file_info.content.decode())['message'])
         return response_or_file_info
-    logger.info('Request passed all upload validations.')
+
     response                           = JsonResponse({"message": "Request passed all upload validations."}, status = 200)
     response["Concent-File-Size"]      = response_or_file_info["size"]
     response["Concent-File-Checksum"]  = response_or_file_info["checksum"]
@@ -61,7 +62,10 @@ def upload(request):
 @csrf_exempt
 @require_safe
 def download(request):
-    logger.debug("Download request received.")
+    logging.log_request_received(
+        request.META['PATH_INFO'] if 'PATH_INFO' in request.META.keys() else '-path to file UNAVAILABLE-',
+        FileTransferToken.Operation.download
+    )
     # The client should not sent Content-Type header with GET requests.
     # FIXME: When running on `manage.py runserver` in development, empty or missing Concent-Type gets replaced
     # with text/plain. gunicorn does not do this. Looks like a bug to me. We'll let it pass for now sice we ignore
@@ -69,25 +73,24 @@ def download(request):
     if request.content_type != 'text/plain' and request.content_type != '':
         return gatekeeper_access_denied_response(
             'Download request cannot have data in the body.',
+            FileTransferToken.Operation.download,
             ErrorCode.REQUEST_BODY_NOT_EMPTY,
         )
 
     path_to_file = request.get_full_path().partition(reverse('gatekeeper:download'))[2]
-    response_or_file_info = parse_headers(request, path_to_file)
+    response_or_file_info = parse_headers(request, path_to_file, FileTransferToken.Operation.download)
     if not isinstance(response_or_file_info, FileTransferToken.FileInfo):
         assert isinstance(response_or_file_info, JsonResponse)
-        logger.info(json.loads(response_or_file_info.content.decode())['message'])
         return response_or_file_info
-    logger.info('Request passed all download validations.')
-
     return JsonResponse({"message": "Request passed all download validations."}, status = 200)
 
 
-def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransferToken.FileInfo, JsonResponse]:
+def parse_headers(request: WSGIRequest, path_to_file: str, operation: FileTransferToken.Operation) -> Union[FileTransferToken.FileInfo, JsonResponse]:
     # Decode and check if request header contains a golem message:
     if 'HTTP_AUTHORIZATION' not in request.META:
         return gatekeeper_access_denied_response(
             "Missing 'Authorization' header.",
+            operation,
             ErrorCode.HEADER_AUTHORIZATION_MISSING,
             path_to_file,
         )
@@ -98,6 +101,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if len(authorization_scheme_and_token) == 1:
         return gatekeeper_access_denied_response(
             "Missing token in the 'Authorization' header.",
+            operation,
             ErrorCode.HEADER_AUTHORIZATION_MISSING_TOKEN,
             path_to_file,
         )
@@ -107,6 +111,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if scheme != 'Golem':
         return gatekeeper_access_denied_response(
             "Unrecognized scheme in the 'Authorization' header.",
+            operation,
             ErrorCode.HEADER_AUTHORIZATION_UNRECOGNIZED_SCHEME,
             path_to_file,
         )
@@ -116,6 +121,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     except binascii.Error:
         return gatekeeper_access_denied_response(
             "Unable to decode token in the 'Authorization' header.",
+            operation,
             ErrorCode.HEADER_AUTHORIZATION_NOT_BASE64_ENCODED_VALUE,
             path_to_file,
         )
@@ -125,6 +131,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     except MessageError:
         return gatekeeper_access_denied_response(
             "Token in the 'Authorization' header is not a valid Golem message.",
+            operation,
             ErrorCode.HEADER_AUTHORIZATION_TOKEN_INVALID_MESSAGE,
             path_to_file,
         )
@@ -135,6 +142,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if 'HTTP_CONCENT_AUTH' not in request.META:
         return gatekeeper_access_denied_response(
             'Missing Concent-Auth header.',
+            operation,
             ErrorCode.AUTH_CLIENT_AUTH_MESSAGE_MISSING,
             path_to_file,
             loaded_golem_message.subtask_id
@@ -151,24 +159,26 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     except (MessageError, binascii.Error):
         return gatekeeper_access_denied_response(
             'Cannot load ClientAuthorization message from Concent-Auth header.',
+            operation,
             ErrorCode.AUTH_CLIENT_AUTH_MESSAGE_INVALID,
             path_to_file,
             loaded_golem_message.subtask_id
         )
 
-    logger.debug(
-        "Client wants to {} file '{}', with subtask_id '{}'. Client public key: '{}'.".format(
+    logging.log_message_under_validation(
             loaded_golem_message.operation,
+            loaded_golem_message.__class__.__name__,
             path_to_file,
             loaded_golem_message.subtask_id,
             concent_client_public_key
-        )
     )
+
     # Check ConcentFileTransferToken each field:
     # -SIGNATURE
     if not isinstance(loaded_golem_message.sig, bytes):
         return gatekeeper_access_denied_response(
             'Empty signature field in FileTransferToken message.',
+            operation,
             ErrorCode.MESSAGE_SIGNATURE_MISSING,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -178,6 +188,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if not isinstance(loaded_golem_message.token_expiration_deadline, int):
         return gatekeeper_access_denied_response(
             'Wrong type of token_expiration_deadline field value.',
+            operation,
             ErrorCode.MESSAGE_TOKEN_EXPIRATION_DEADLINE_WRONG_TYPE,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -188,6 +199,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if current_time > loaded_golem_message.token_expiration_deadline:
         return gatekeeper_access_denied_response(
             'token_expiration_deadline has passed.',
+            operation,
             ErrorCode.MESSAGE_TOKEN_EXPIRATION_DEADLINE_PASSED,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -198,6 +210,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if not isinstance(loaded_golem_message.storage_cluster_address, str):
         return gatekeeper_access_denied_response(
             'Wrong type of storage_cluster_address field value.',
+            operation,
             ErrorCode.MESSAGE_STORAGE_CLUSTER_WRONG_TYPE,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -209,6 +222,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     except ValidationError:
         return gatekeeper_access_denied_response(
             'storage_cluster_address is not a valid URL.',
+            operation,
             ErrorCode.MESSAGE_STORAGE_CLUSTER_INVALID_URL,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -217,6 +231,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if loaded_golem_message.storage_cluster_address != settings.STORAGE_CLUSTER_ADDRESS:
         return gatekeeper_access_denied_response(
             'This token does not allow file transfers to/from the cluster you are trying to access.',
+            operation,
             ErrorCode.MESSAGE_STORAGE_CLUSTER_WRONG_CLUSTER,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -227,6 +242,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if not isinstance(loaded_golem_message.authorized_client_public_key, bytes):
         return gatekeeper_access_denied_response(
             'Wrong type of authorized_client_public_key field value.',
+            operation,
             ErrorCode.MESSAGE_AUTHORIZED_CLIENT_PUBLIC_KEY_WRONG_TYPE,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -236,6 +252,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if concent_client_public_key != authorized_client_public_key_base64:
         return gatekeeper_access_denied_response(
             'You are not authorized to use this token.',
+            operation,
             ErrorCode.MESSAGE_AUTHORIZED_CLIENT_PUBLIC_KEY_UNAUTHORIZED_CLIENT,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -246,6 +263,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if request.method == 'POST' and loaded_golem_message.operation != FileTransferToken.Operation.upload:
         return gatekeeper_access_denied_response(
             'Upload requests must use POST method.',
+            operation,
             ErrorCode.MESSAGE_OPERATION_INVALID,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -254,6 +272,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if request.method in ['GET', 'HEAD'] and loaded_golem_message.operation != FileTransferToken.Operation.download:
         return gatekeeper_access_denied_response(
             'Download requests must use GET or HEAD method.',
+            operation,
             ErrorCode.MESSAGE_OPERATION_INVALID,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -264,6 +283,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if not all(isinstance(file, dict) for file in loaded_golem_message.files):
         return gatekeeper_access_denied_response(
             'Wrong type of files field value.',
+            operation,
             ErrorCode.MESSAGE_FILES_WRONG_TYPE,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -273,6 +293,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if len(transfer_token_paths_to_files) != len(set(transfer_token_paths_to_files)):
         return gatekeeper_access_denied_response(
             'File paths in the token must be unique',
+            operation,
             ErrorCode.MESSAGE_FILES_PATHS_NOT_UNIQUE,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -282,6 +303,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if not all(isinstance(file["checksum"], str) for file in loaded_golem_message.files):
         return gatekeeper_access_denied_response(
             "'checksum' must be a string.",
+            operation,
             ErrorCode.MESSAGE_FILES_CHECKSUM_WRONG_TYPE,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -290,6 +312,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if any((len(file["checksum"]) == 0 or file["checksum"].isspace()) for file in loaded_golem_message.files):
         return gatekeeper_access_denied_response(
             "'checksum' cannot be blank or contain only whitespace.",
+            operation,
             ErrorCode.MESSAGE_FILES_CHECKSUM_EMPTY,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -298,6 +321,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if not all(":" in file["checksum"] for file in loaded_golem_message.files):
         return gatekeeper_access_denied_response(
             "'checksum' must consist of two parts separated with a semicolon.",
+            operation,
             ErrorCode.MESSAGE_FILES_CHECKSUM_WRONG_FORMAT,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -307,6 +331,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if not set(checksum_type for checksum_type, checksum in file_checksums).issubset(set(HashingAlgorithm._value2member_map_)):  # type: ignore
         return gatekeeper_access_denied_response(
             "One of the checksums is from an unsupported hashing algorithm.",
+            operation,
             ErrorCode.MESSAGE_FILES_CHECKSUM_INVALID_ALGORITHM,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -317,6 +342,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if any(VALID_SHA1_HASH_REGEX.fullmatch(file_checksum[1]) is None for file_checksum in file_checksums):
         return gatekeeper_access_denied_response(
             "Invalid SHA1 hash.",
+            operation,
             ErrorCode.MESSAGE_FILES_CHECKSUM_INVALID_SHA1_HASH,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -327,6 +353,7 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     if any((file_size is None) for file_size in file_sizes):
         return gatekeeper_access_denied_response(
             "'size' must be an integer.",
+            operation,
             ErrorCode.MESSAGE_FILES_SIZE_EMPTY,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -338,15 +365,17 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
         except (ValueError, TypeError):
             return gatekeeper_access_denied_response(
                 "'size' must be an integer.",
+                operation,
                 ErrorCode.MESSAGE_FILES_SIZE_WRONG_TYPE,
                 path_to_file,
                 loaded_golem_message.subtask_id,
                 concent_client_public_key
             )
 
-    if any(int(file["size"]) < 0  for file in loaded_golem_message.files):
+    if any(int(file["size"]) < 0 for file in loaded_golem_message.files):
         return gatekeeper_access_denied_response(
             "'size' must not be negative.",
+            operation,
             ErrorCode.MESSAGE_FILES_SIZE_NEGATIVE,
             path_to_file,
             loaded_golem_message.subtask_id,
@@ -356,11 +385,19 @@ def parse_headers(request: WSGIRequest, path_to_file: str) -> Union[FileTransfer
     matching_files = [file for file in loaded_golem_message.files if path_to_file == file['path']]
 
     if len(matching_files) == 1:
+        logging.log_message_successfully_validated(
+            loaded_golem_message.operation,
+            loaded_golem_message.__class__.__name__,
+            path_to_file,
+            loaded_golem_message.subtask_id,
+            concent_client_public_key
+        )
         return matching_files[0]
     else:
         assert len(matching_files) == 0
         return gatekeeper_access_denied_response(
             'Your token does not authorize you to transfer the requested file.',
+            operation,
             ErrorCode.MESSAGE_FILES_PATH_NOT_LISTED_IN_FILES,
             path_to_file,
             loaded_golem_message.subtask_id,

--- a/concent_api/utils/logging.py
+++ b/concent_api/utils/logging.py
@@ -1,9 +1,9 @@
 from logging                        import getLogger
 
+from golem_messages.message import FileTransferToken
 from golem_messages.message.base    import Message
 
 from utils.helpers                  import get_field_from_message
-
 
 logger = getLogger(__name__)
 
@@ -224,3 +224,64 @@ def get_subtask_id_for_logging(message):
     if not isinstance(subtask_id, str):
         subtask_id = ''
     return subtask_id
+
+
+def log_request_received(path_to_file, operation: FileTransferToken.Operation):
+    logger.debug("{} request received. Path to file: '{}'".format(
+        operation.capitalize(),
+        path_to_file
+    ))
+
+
+@replace_element_to_unavailable_instead_of_none
+def log_message_under_validation(
+    operation: FileTransferToken.Operation,
+    message_type: str,
+    file_path: str,
+    subtask_id: bytes,
+    public_key: bytes
+):
+
+    logger.debug("{} request will be validated. Message type: '{}'. File: '{}', with subtask_id '{}'. Client public key: '{}'".format(
+        operation.capitalize(),
+        message_type,
+        file_path,
+        subtask_id,
+        public_key
+    ))
+
+
+@replace_element_to_unavailable_instead_of_none
+def log_message_successfully_validated(
+    operation: FileTransferToken.Operation,
+    message_type: str,
+    file_path: str,
+    subtask_id: bytes,
+    public_key: bytes
+):
+    logger.info("{} request passed all validations.  Message type: '{}'. File: '{}', with subtask_id '{}'. Client public key: '{}'".format(
+        operation.capitalize(),
+        message_type,
+        file_path,
+        subtask_id,
+        public_key
+    ))
+
+
+@replace_element_to_unavailable_instead_of_none
+def log_operation_validation_failed(
+    operation: FileTransferToken.Operation,
+    message: str,
+    error_code: str,
+    path: str,
+    subtask_id: str,
+    client_key: str
+):
+    logger.info("{} validation failed. Message: {} Error code: '{}'. File '{}', with subtask_id '{}'. Client public key: '{}'".format(
+        operation.capitalize(),
+        message,
+        error_code,
+        path,
+        subtask_id,
+        client_key
+    ))


### PR DESCRIPTION
I've made 'two levels' of logging. INFO for regular-positive way (like endpoint received message, positive validation..) and WARNING for 'negative' infos- like validation errors. 

After @bartoszbetka and @cameel  comments there is no more logs related invalid messages from client in warnings