### PR TITLE
remove '_' from api-integration-tests 'task_id'

### DIFF
--- a/concent_api/api-integration-force-get-task-result-test.py
+++ b/concent_api/api-integration-force-get-task-result-test.py
@@ -73,7 +73,7 @@ def upload_file_to_storage_cluster(file_content, file_path, upload_token):
 @count_fails
 def test_case_1_test_for_existing_file(cluster_consts, cluster_url, test_id):
     current_time    = get_current_utc_timestamp()
-    (subtask_id, task_id) = get_task_id_and_subtask_id(test_id, 'existing_file')
+    (subtask_id, task_id) = get_task_id_and_subtask_id(test_id, 'existingfile')
 
     file_content = task_id
     file_size = len(file_content)
@@ -147,7 +147,7 @@ def test_case_1_test_for_existing_file(cluster_consts, cluster_url, test_id):
 @count_fails
 def test_case_2_test_for_non_existing_file(cluster_consts, cluster_url, test_id):
     current_time    = get_current_utc_timestamp()
-    (subtask_id, task_id) = get_task_id_and_subtask_id(test_id, 'non_existing_file')
+    (subtask_id, task_id) = get_task_id_and_subtask_id(test_id, 'nonexistingfile')
 
     api_request(
         cluster_url,

--- a/concent_api/api_testing_common.py
+++ b/concent_api/api_testing_common.py
@@ -242,8 +242,8 @@ def parse_command_line(command_line):
 
 
 def get_task_id_and_subtask_id(test_id, case_name):
-    task_id = f'task_{case_name}_{test_id}'
-    subtask_id = 'sub_' + task_id
+    task_id = f'task{case_name}{test_id}'
+    subtask_id = 'sub' + task_id
     return (subtask_id, task_id)
 
 
@@ -269,7 +269,7 @@ def get_tests_list(patterns, all_objects):
 def execute_tests(tests_to_execute, objects, **kwargs):
     tests = [objects[name] for name in tests_to_execute]
     for test in tests:
-        test_id = kwargs['test_id'] + test.__name__
+        test_id = kwargs['test_id'] + '0'.join(test.__name__.split('_'))
         kw = {k: v for k, v in kwargs.items() if k != 'test_id'}
         test(test_id=test_id, **kw)
         print("-" * 80)


### PR DESCRIPTION
Just something we miss in previous PR