### PR TITLE
Fix concent verification fixes

### DIFF
--- a/concent_api/core/message_handlers.py
+++ b/concent_api/core/message_handlers.py
@@ -1287,12 +1287,11 @@ def handle_send_subtask_results_verify(
 
     send_blender_verification_request(compute_task_def)
 
-    encoded_client_public_key = b64encode(provider_public_key)
     ack_subtask_results_verify = message.concents.AckSubtaskResultsVerify(
         subtask_results_verify=subtask_results_verify,
         file_transfer_token=create_file_transfer_token_for_golem_client(
             report_computed_task,
-            encoded_client_public_key,
+            requestor_public_key,
             FileTransferToken.Operation.upload,
             should_add_source=True,
         ),

--- a/concent_api/core/message_handlers.py
+++ b/concent_api/core/message_handlers.py
@@ -1265,7 +1265,8 @@ def handle_send_subtask_results_verify(
             error_code=ErrorCode.QUEUE_SUBTASK_STATE_TRANSITION_NOT_ALLOWED,
         )
     if not base.is_account_status_positive(  # pylint: disable=no-value-for-parameter
-        client_eth_address      = task_to_compute.requestor_ethereum_address,
+        client_eth_address=task_to_compute.requestor_ethereum_address,
+        pending_value=task_to_compute.price,
     ):
         return message.concents.ServiceRefused(
             reason=message.concents.ServiceRefused.REASON.TooSmallRequestorDeposit,

--- a/concent_api/core/tests/test_integration_subtask_results_verify.py
+++ b/concent_api/core/tests/test_integration_subtask_results_verify.py
@@ -1,5 +1,3 @@
-from base64 import b64encode
-
 import mock
 from django.conf import settings
 from django.test import override_settings
@@ -78,7 +76,7 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
         self._test_response(
             response,
             status=200,
-            key=self.PROVIDER_PRIVATE_KEY,
+            key=self.REQUESTOR_PRIVATE_KEY,
             message_type=message.concents.ServiceRefused,
             fields={
                 'reason': message.concents.ServiceRefused.REASON.DuplicateRequest,
@@ -184,7 +182,7 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
         self._test_response(
             response,
             status=200,
-            key=self.PROVIDER_PRIVATE_KEY,
+            key=self.REQUESTOR_PRIVATE_KEY,
             message_type=message.concents.ServiceRefused,
             fields={
                 'reason': message.concents.ServiceRefused.REASON.InvalidRequest,
@@ -216,14 +214,15 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
                 )
 
         is_account_status_positive_mock.assert_called_with(
-            client_eth_address=self.report_computed_task.task_to_compute.requestor_ethereum_address
+            client_eth_address=self.report_computed_task.task_to_compute.requestor_ethereum_address,
+            pending_value=0,
         )
 
         # then
         self._test_response(
             response,
             status=200,
-            key=self.PROVIDER_PRIVATE_KEY,
+            key=self.REQUESTOR_PRIVATE_KEY,
             message_type=message.concents.ServiceRefused,
             fields={
                 'reason': message.concents.ServiceRefused.REASON.TooSmallRequestorDeposit,
@@ -255,7 +254,7 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
         self._test_response(
             response,
             status=200,
-            key=self.PROVIDER_PRIVATE_KEY,
+            key=self.REQUESTOR_PRIVATE_KEY,
             message_type=message.concents.ServiceRefused,
             fields={
                 'reason': message.concents.ServiceRefused.REASON.InvalidRequest,
@@ -288,7 +287,7 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
         self._test_response(
             response,
             status=200,
-            key=self.PROVIDER_PRIVATE_KEY,
+            key=self.REQUESTOR_PRIVATE_KEY,
             message_type=message.concents.ServiceRefused,
             fields={
                 'reason': message.concents.ServiceRefused.REASON.InvalidRequest,
@@ -318,7 +317,8 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
                     )
 
         is_account_status_positive_mock.assert_called_with(
-            client_eth_address=self.report_computed_task.task_to_compute.requestor_ethereum_address
+            client_eth_address=self.report_computed_task.task_to_compute.requestor_ethereum_address,
+            pending_value=0,
         )
         send_verification_request_mock.assert_called_once_with(
             subtask_id=self.subtask_id,
@@ -332,7 +332,7 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
         self._test_response(
             response,
             status=200,
-            key=self.PROVIDER_PRIVATE_KEY,
+            key=self.REQUESTOR_PRIVATE_KEY,
             message_type=message.concents.AckSubtaskResultsVerify,
             fields={
                 'subtask_results_verify': self._prepare_subtask_results_verify(serialized_subtask_results_verify),
@@ -460,11 +460,10 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
         with freeze_time(subtask_results_verify_time_str):
             file_transfer_token = create_file_transfer_token_for_golem_client(
                 self.report_computed_task,
-                b64encode(self.PROVIDER_PUBLIC_KEY),
+                self.REQUESTOR_PUBLIC_KEY,
                 message.FileTransferToken.Operation.upload,
                 should_add_source=True,
             )
-            file_transfer_token.encrypted = False
         return file_transfer_token
 
     def _create_serialized_subtask_results_verify(

--- a/concent_api/utils/helpers.py
+++ b/concent_api/utils/helpers.py
@@ -132,7 +132,6 @@ def get_validated_client_public_key_from_client_message(golem_message: message.b
             message.ForceReportComputedTask,
             message.concents.ForceSubtaskResults,
             message.concents.ForcePayment,
-            message.concents.SubtaskResultsVerify,
         )):
             client_public_key = task_to_compute.provider_public_key
             validate_public_key(client_public_key, 'provider_public_key')
@@ -141,6 +140,7 @@ def get_validated_client_public_key_from_client_message(golem_message: message.b
             message.RejectReportComputedTask,
             message.concents.ForceGetTaskResult,
             message.concents.ForceSubtaskResultsResponse,
+            message.concents.SubtaskResultsVerify,
         )):
             client_public_key = task_to_compute.requestor_public_key
             validate_public_key(client_public_key, 'requestor_public_key')


### PR DESCRIPTION
Resolves issues related to verification on concent-api side.

Issued fixed:
- Change provider to request public key usage in AckSubtaskResultsVerify response.
- Set SubtaskResultsVerify as requestor message.
- Add pending_value to payment backend call in additional verification use case.