### PR TITLE
Fix regex in conductor/urls to match all files

### DIFF
--- a/concent_api/conductor/urls.py
+++ b/concent_api/conductor/urls.py
@@ -3,5 +3,5 @@ from django.conf.urls import url
 from .views import report_upload
 
 urlpatterns = [
-    url(r'^report-upload/(?P<file_path>.+\.zip)$', report_upload, name='report-upload'),
+    url(r'^report-upload/(?P<file_path>.+)$', report_upload, name='report-upload'),
 ]


### PR DESCRIPTION
resolves: https://github.com/golemfactory/concent/issues/446
- Previously only file with ".zip" extension were supported