### PR TITLE
Add parameters name to arguments in file_path creation functions

### DIFF
--- a/concent_api/api-integration-force-get-task-result-test.py
+++ b/concent_api/api-integration-force-get-task-result-test.py
@@ -78,7 +78,10 @@ def test_case_1_test_for_existing_file(cluster_consts, cluster_url, test_id):
     file_content = task_id
     file_size = len(file_content)
     file_check_sum = 'sha1:' + hashlib.sha1(file_content.encode()).hexdigest()
-    file_path = get_storage_result_file_path(task_id, subtask_id)
+    file_path = get_storage_result_file_path(
+        task_id=task_id,
+        subtask_id=subtask_id,
+    )
 
     # Case 1 - test for existing file
     api_request(

--- a/concent_api/core/queue_operations.py
+++ b/concent_api/core/queue_operations.py
@@ -6,8 +6,14 @@ from utils.helpers import get_storage_source_file_path
 def send_blender_verification_request(compute_task_def):
     task_id = compute_task_def['task_id']
     subtask_id = compute_task_def['subtask_id']
-    source_package_path = get_storage_source_file_path(subtask_id, task_id)
-    result_package_path = get_storage_result_file_path(subtask_id, task_id)
+    source_package_path = get_storage_source_file_path(
+        subtask_id=subtask_id,
+        task_id=task_id,
+    )
+    result_package_path = get_storage_result_file_path(
+        subtask_id=subtask_id,
+        task_id=task_id,
+    )
     output_format = compute_task_def['extra_data']['output_format']
     scene_file = compute_task_def['extra_data']['scene_file']
     blender_verification_request.delay(

--- a/concent_api/core/tests/test_integration_subtask_results_verify.py
+++ b/concent_api/core/tests/test_integration_subtask_results_verify.py
@@ -36,8 +36,14 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
         super().setUp()
         self.task_id = "task1"
         self.subtask_id = "subtask1"
-        self.source_package_path = get_storage_source_file_path(self.subtask_id, self.task_id)
-        self.result_package_path = get_storage_result_file_path(self.subtask_id, self.task_id)
+        self.source_package_path = get_storage_source_file_path(
+            subtask_id=self.subtask_id,
+            task_id=self.task_id,
+        )
+        self.result_package_path = get_storage_result_file_path(
+            subtask_id=self.subtask_id,
+            task_id=self.task_id,
+        )
         self.report_computed_task = self._create_report_computed_task()
 
     def test_that_concent_responds_with_service_refused_when_verification_for_this_subtask_is_duplicated(self):
@@ -339,13 +345,13 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
                 'file_transfer_token': self._prepare_file_transfer_token(subtask_results_verify_time_str),
                 'file_transfer_token.files': [
                     message.FileTransferToken.FileInfo(
-                        path='blender/result/subtask1/subtask1.task1.zip',
+                        path='blender/result/task1/task1.subtask1.zip',
                         checksum='sha1:4452d71687b6bc2c9389c3349fdc17fbd73b833b',
                         size=1,
                         category=message.FileTransferToken.FileInfo.Category.results,
                     ),
                     message.FileTransferToken.FileInfo(
-                        path='blender/source/subtask1/subtask1.task1.zip',
+                        path='blender/source/task1/task1.subtask1.zip',
                         checksum='sha1:230fb0cad8c7ed29810a2183f0ec1d39c9df3f4a',
                         size=1,
                         category=message.FileTransferToken.FileInfo.Category.resources,

--- a/concent_api/core/tests/test_unit_transfer_operation.py
+++ b/concent_api/core/tests/test_unit_transfer_operation.py
@@ -105,10 +105,16 @@ class FileTransferTokenCreationTest(TestCase):
         report_computed_task = ReportComputedTaskFactory()
         token = create_file_transfer_token_for_concent(
             subtask_id=report_computed_task.subtask_id,
-            source_package_path=get_storage_source_file_path(report_computed_task.task_id, report_computed_task.subtask_id),
+            source_package_path=get_storage_source_file_path(
+                subtask_id=report_computed_task.subtask_id,
+                task_id=report_computed_task.task_id,
+            ),
             source_size=report_computed_task.task_to_compute.size,
             source_package_hash=report_computed_task.task_to_compute.package_hash,
-            result_package_path=get_storage_result_file_path(report_computed_task.task_id, report_computed_task.subtask_id),
+            result_package_path=get_storage_result_file_path(
+                subtask_id=report_computed_task.subtask_id,
+                task_id=report_computed_task.task_id,
+            ),
             result_size=report_computed_task.size,
             result_package_hash=report_computed_task.package_hash,
             operation=FileTransferToken.Operation.download,

--- a/concent_api/core/transfer_operations.py
+++ b/concent_api/core/transfer_operations.py
@@ -140,10 +140,16 @@ def create_file_transfer_token_for_golem_client(
     task_id = report_computed_task.task_to_compute.compute_task_def['task_id']
     return _create_file_transfer_token(
         subtask_id=subtask_id,
-        source_package_path=get_storage_source_file_path(task_id, subtask_id),
+        source_package_path=get_storage_source_file_path(
+            subtask_id=subtask_id,
+            task_id=task_id,
+        ),
         source_size=report_computed_task.task_to_compute.size,
         source_package_hash=report_computed_task.task_to_compute.package_hash,
-        result_package_path=get_storage_result_file_path(task_id, subtask_id),
+        result_package_path=get_storage_result_file_path(
+            subtask_id=subtask_id,
+            task_id=task_id,
+        ),
         result_size=report_computed_task.size,
         result_package_hash=report_computed_task.package_hash,
         authorized_client_public_key=authorized_client_public_key,
@@ -227,7 +233,10 @@ def request_upload_status(report_computed_task: message.ReportComputedTask) -> b
 
     file_transfer_token = create_file_transfer_token_for_concent(
         subtask_id=report_computed_task.subtask_id,
-        result_package_path=get_storage_result_file_path(report_computed_task.task_id, report_computed_task.subtask_id),
+        result_package_path=get_storage_result_file_path(
+            subtask_id=report_computed_task.subtask_id,
+            task_id=report_computed_task.task_id,
+        ),
         result_size=report_computed_task.size,
         result_package_hash=report_computed_task.package_hash,
         operation=FileTransferToken.Operation.download

--- a/concent_api/utils/helpers.py
+++ b/concent_api/utils/helpers.py
@@ -116,15 +116,18 @@ def get_storage_file_path(category, subtask_id, task_id):
     return f'blender/{category}/{task_id}/{task_id}.{subtask_id}.zip'
 
 
-def get_storage_result_file_path(subtask_id, task_id):
+def get_storage_result_file_path(subtask_id=None, task_id=None):
+    assert subtask_id is not None and task_id is not None
     return get_storage_file_path('result', subtask_id, task_id)
 
 
-def get_storage_scene_file_path(subtask_id, task_id):
+def get_storage_scene_file_path(subtask_id=None, task_id=None):
+    assert subtask_id is not None and task_id is not None
     return get_storage_file_path('scene', subtask_id, task_id)
 
 
-def get_storage_source_file_path(subtask_id, task_id):
+def get_storage_source_file_path(subtask_id=None, task_id=None):
+    assert subtask_id is not None and task_id is not None
     return get_storage_file_path('source', subtask_id, task_id)
 
 

--- a/concent_api/verifier/tests/test_integration_verification.py
+++ b/concent_api/verifier/tests/test_integration_verification.py
@@ -41,12 +41,12 @@ class VerifierVerificationIntegrationTest(ConcentIntegrationTestCase):
         )
 
         self.source_package_path = get_storage_source_file_path(
-            self.compute_task_def['task_id'],
-            self.compute_task_def['subtask_id'],
+            task_id=self.compute_task_def['task_id'],
+            subtask_id=self.compute_task_def['subtask_id'],
         )
         self.result_package_path = get_storage_result_file_path(
-            self.compute_task_def['task_id'],
-            self.compute_task_def['subtask_id'],
+            task_id=self.compute_task_def['task_id'],
+            subtask_id=self.compute_task_def['subtask_id'],
         )
         self.report_computed_task=self._get_deserialized_report_computed_task(
             package_hash='sha1:95a0f391c7ad86686ab1366bcd519ba5ab3cce89',


### PR DESCRIPTION
Depends on: #456 
Necessity appeared when I started testing verification. Sometimes file paths were created with task_id as a first parameter, sometimes as second.