### PR TITLE
Add function to verify sizes of images

### DIFF
--- a/concent_api/verifier/tasks.py
+++ b/concent_api/verifier/tasks.py
@@ -24,6 +24,7 @@ from common.decorators import provides_concent_feature
 from common.logging import log_string_message
 from common.helpers import upload_file_to_storage_cluster
 from .exceptions import VerificationError
+from .utils import are_image_sizes_and_color_channels_equal
 from .utils import clean_directory
 from .utils import delete_file
 from .utils import generate_blender_output_file_name
@@ -300,6 +301,18 @@ def blender_verification_order(
             VerificationResult.ERROR.name,
             str(exception),
             ErrorCode.VERIFIER_LOADING_FILES_INTO_MEMORY_FAILED.name
+        )
+        return
+
+    if not are_image_sizes_and_color_channels_equal(image_1, image_2):
+        log_string_message(
+            logger,
+            f'Blender verification failed. Sizes in pixels of images are not equal. SUBTASK_ID: {subtask_id}.'
+            f'VerificationResult: {VerificationResult.MISMATCH.name}'
+        )
+        verification_result.delay(
+            subtask_id,
+            VerificationResult.MISMATCH.name,
         )
         return
 

--- a/concent_api/verifier/tests/test_integration_verification.py
+++ b/concent_api/verifier/tests/test_integration_verification.py
@@ -15,7 +15,6 @@ from common.helpers import get_storage_source_file_path
 from common.testing_helpers import generate_ecc_key_pair
 from ..tasks import blender_verification_order
 
-
 (CONCENT_PRIVATE_KEY, CONCENT_PUBLIC_KEY) = generate_ecc_key_pair()
 
 
@@ -83,6 +82,7 @@ class VerifierVerificationIntegrationTest(ConcentIntegrationTestCase):
             mock.patch('verifier.tasks.get_files_list_from_archive', return_value=['file_name']) as mock_get_files_list_from_archive, \
             mock.patch('verifier.tasks.cv2.imread', autospec=True) as mock_imread, \
             mock.patch('verifier.tasks.compare_ssim', return_value=1.0) as mock_compare_ssim, \
+            mock.patch('verifier.tasks.are_image_sizes_and_color_channels_equal', return_value=True), \
             mock.patch('verifier.tasks.delete_file', autospec=True) as mock_delete_file:  # noqa: E125
             blender_verification_order(
                 subtask_id=self.compute_task_def['subtask_id'],
@@ -124,6 +124,7 @@ class VerifierVerificationIntegrationTest(ConcentIntegrationTestCase):
             mock.patch('verifier.tasks.get_files_list_from_archive', autospec=True, return_value=['file_name']) as mock_get_files_list_from_archive, \
             mock.patch('verifier.tasks.cv2.imread', autospec=True) as mock_imread, \
             mock.patch('verifier.tasks.compare_ssim', return_value=(settings.VERIFIER_MIN_SSIM - 0.1)) as mock_compare_ssim, \
+            mock.patch('verifier.tasks.are_image_sizes_and_color_channels_equal', return_value=True), \
             mock.patch('verifier.tasks.delete_file', autospec=True) as mock_delete_file:  # noqa: E125
             blender_verification_order(
                 subtask_id=self.compute_task_def['subtask_id'],
@@ -335,6 +336,7 @@ class VerifierVerificationIntegrationTest(ConcentIntegrationTestCase):
             mock.patch('verifier.tasks.get_files_list_from_archive', return_value=['file_name']) as mock_get_files_list_from_archive, \
             mock.patch('verifier.tasks.cv2.imread', autospec=True) as mock_imread, \
             mock.patch('verifier.tasks.compare_ssim', return_value=1.0) as mock_compare_ssim, \
+            mock.patch('verifier.tasks.are_image_sizes_and_color_channels_equal', return_value=True), \
             mock.patch('verifier.tasks.delete_file') as mock_delete_file:  # noqa: E125
             blender_verification_order(
                 subtask_id=self.compute_task_def['subtask_id'],
@@ -415,6 +417,7 @@ class VerifierVerificationIntegrationTest(ConcentIntegrationTestCase):
             mock.patch('builtins.open', autospec=True, side_effect=[io.StringIO('test'), io.StringIO('test')]), \
             mock.patch('verifier.tasks.get_files_list_from_archive', autospec=True, return_value=['file_name']) as mock_get_files_list_from_archive, \
             mock.patch('verifier.tasks.cv2.imread', autospec=True, side_effect=[None, None]) as mock_imread, \
+            mock.patch('verifier.tasks.are_image_sizes_and_color_channels_equal', return_value=True), \
             mock.patch('verifier.tasks.delete_file') as mock_delete_file:  # noqa: E125
             blender_verification_order(
                 subtask_id=self.compute_task_def['subtask_id'],
@@ -457,6 +460,7 @@ class VerifierVerificationIntegrationTest(ConcentIntegrationTestCase):
             mock.patch('verifier.tasks.get_files_list_from_archive', return_value=['file_name']) as mock_get_files_list_from_archive, \
             mock.patch('verifier.tasks.cv2.imread', autospec=True) as mock_imread, \
             mock.patch('verifier.tasks.compare_ssim', side_effect=ValueError('error')) as mock_compare_ssim, \
+            mock.patch('verifier.tasks.are_image_sizes_and_color_channels_equal', return_value=True), \
             mock.patch('verifier.tasks.delete_file', autospec=True) as mock_delete_file:  # noqa: E125
             blender_verification_order(
                 subtask_id=self.compute_task_def['subtask_id'],

--- a/concent_api/verifier/tests/test_utils.py
+++ b/concent_api/verifier/tests/test_utils.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+
+from mock import mock
+from numpy.core.records import ndarray
+
+from verifier.utils import are_image_sizes_and_color_channels_equal
+
+
+class VerifierVerificationIntegrationTest(TestCase):
+
+    def test_that_are_image_sizes_and_color_channels_equal_should_return_false_if_sizes_in_pixels_are_not_equal(self):
+        image1 = mock.create_autospec(spec=ndarray, spec_set=True)
+        image2 = mock.create_autospec(spec=ndarray, spec_set=True)
+        image1.shape = (2000, 3000, 3)
+        image2.shape = (3000, 4000, 3)
+        result = are_image_sizes_and_color_channels_equal(image1, image2)
+        self.assertEqual(result, False)
+
+    def test_that_are_image_sizes_and_color_channels_equal_should_return_false_if_color_channels_are_not_equal(self):
+        image1 = mock.create_autospec(spec=ndarray, spec_set=True)
+        image2 = mock.create_autospec(spec=ndarray, spec_set=True)
+        image1.shape = (2000, 3000, 3)
+        image2.shape = (2000, 3000)
+        result = are_image_sizes_and_color_channels_equal(image1, image2)
+        self.assertEqual(result, False)
+
+    def test_that_are_image_sizes_and_color_channels_equal_should_return_true_if_sizes_in_pixels_are_equal(self):
+        image1 = mock.create_autospec(spec=ndarray, spec_set=True)
+        image2 = mock.create_autospec(spec=ndarray, spec_set=True)
+        image1.shape = (2000, 3000, 3)
+        image2.shape = (2000, 3000, 3)
+        result = are_image_sizes_and_color_channels_equal(image1, image2)
+        self.assertEqual(result, True)

--- a/concent_api/verifier/utils.py
+++ b/concent_api/verifier/utils.py
@@ -10,6 +10,7 @@ from django.conf import settings
 
 from golem_messages import message
 from golem_messages.shortcuts import dump
+from numpy.core.records import ndarray
 
 from .constants import UNPACK_CHUNK_SIZE
 
@@ -108,3 +109,7 @@ def generate_upload_file_name(subtask_id, extension):
 
 def generate_verifier_storage_file_path(file_name):
     return os.path.join(settings.VERIFIER_STORAGE_PATH, file_name)
+
+
+def are_image_sizes_and_color_channels_equal(image1: ndarray, image2: ndarray) -> bool:
+    return image1.shape == image2.shape


### PR DESCRIPTION
resolves https://github.com/golemfactory/concent/issues/535

There is only a size of images checked (in pixels). It is also possible to check the number of channels if image is in color. If one image would be in color and second in grayscale it will be easy to check. I'm only not  sure if we want it.