### PR TITLE
Fix requirements.lock

### DIFF
--- a/concent_api/requirements.lock
+++ b/concent_api/requirements.lock
@@ -1,3 +1,4 @@
+--find-links https://builds.golem.network/simple/pyelliptic
 amqp==2.3.2
 apipkg==1.4
 asn1crypto==0.24.0
@@ -19,8 +20,7 @@ cytoolz==0.9.0.1
 dask==0.18.1
 decorator==4.3.0
 Django==1.11.13
-django-constance==2.2.0
-django-picklefield==1.0.0
+django-constance[database]==2.2.0
 eth-abi==0.5.0
 eth-keyfile==0.4.1
 eth-keys==0.1.0b4


### PR DESCRIPTION
Restores removed:
`--find-links https://builds.golem.network/simple/pyelliptic`
and
`django-constance[database]==2.2.0`