### PR TITLE
Add validation of ComputeTaskDef in for all Golem message handlers

### DIFF
--- a/concent_api/common/tests/test_api_view.py
+++ b/concent_api/common/tests/test_api_view.py
@@ -222,6 +222,8 @@ class ApiViewTransactionTestCase(TransactionTestCase):
         compute_task_def['deadline'] = message_timestamp
         compute_task_def['extra_data'] = {
             'frames': [1],
+            'output_format': 'PNG',
+            'scene_file': 'kitten.blend',
         }
         task_to_compute = tasks.TaskToComputeFactory(
             compute_task_def=compute_task_def,

--- a/concent_api/core/tests/test_core_views.py
+++ b/concent_api/core/tests/test_core_views.py
@@ -73,6 +73,8 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
         compute_task_def['deadline'] = self.message_timestamp + 600
         compute_task_def['extra_data'] = {
             'frames': [1],
+            'output_format': 'PNG',
+            'scene_file': 'kitten.blend',
         }
         task_to_compute = self._get_deserialized_task_to_compute(
             compute_task_def = compute_task_def
@@ -469,6 +471,8 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             compute_task_def['deadline']    = deadline
             compute_task_def['extra_data'] = {
                 'frames': [1],
+                'output_format': 'PNG',
+                'scene_file': 'kitten.blend',
             }
 
             deserialized_task_to_compute = self._get_deserialized_task_to_compute(


### PR DESCRIPTION
- New function `validate_compute_task_def` has been added; it is called within `validate_task_to_compute`.
- Unit tests have been added
- Existing tests have been adapted.

resolves: https://github.com/golemfactory/concent/issues/600