### PR TITLE
Fix pylintrc: disable warning that concent_api/.pytest_cache/__init__.py is missing

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS, .pytest_cache
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.


### PR DESCRIPTION
Get rid of unnecessary warning (`pytest` creates cache, and `pylint`thought it is a python module with missing `__init__.py`)