### PR TITLE
Add unit tests to method in verifier.utils

### DIFF
--- a/concent_api/core/tests/test_integration_subtask_results_verify.py
+++ b/concent_api/core/tests/test_integration_subtask_results_verify.py
@@ -17,7 +17,6 @@ from core.transfer_operations import create_file_transfer_token_for_golem_client
 from common.constants import ErrorCode
 from common.helpers import get_current_utc_timestamp
 from common.helpers import get_storage_result_file_path
-from common.helpers import get_storage_scene_file_path
 from common.helpers import get_storage_source_file_path
 from common.helpers import parse_timestamp_to_utc_datetime
 from common.testing_helpers import generate_ecc_key_pair
@@ -592,7 +591,7 @@ class SubtaskResultsVerifyIntegrationTest(ConcentIntegrationTestCase):
                 'outfilebasename': 'Heli-cycles(3)',
                 'output_format': BlenderSubtaskDefinition.OutputFormat.JPG.name,  # pylint: disable=no-member
                 'path_root': '/home/dariusz/Documents/tasks/resources',
-                'scene_file': get_storage_scene_file_path(self.subtask_id, self.task_id),
+                'scene_file': '/golem/resources/scene-Helicopter-27-internal.blend',
                 'script_src': '# This template is rendered by',
                 'start_task': 6,
                 'total_tasks': 8

--- a/concent_api/core/validation.py
+++ b/concent_api/core/validation.py
@@ -293,6 +293,14 @@ def validate_positive_integer_value(value):
         )
 
 
+def validate_scene_file(scene_file):
+    if not scene_file.endswith('.blend'):
+        raise ConcentValidationError(
+            f'{scene_file} must ends with ".blend" filename extension',
+            ErrorCode.MESSAGE_INVALID
+        )
+
+
 def validate_compute_task_def(compute_task_def: message.tasks.ComputeTaskDef) -> None:
     string_fields = ["output_format", "scene_file"]
     other_mandatory_fields = ["frames"]
@@ -324,3 +332,5 @@ def validate_compute_task_def(compute_task_def: message.tasks.ComputeTaskDef) ->
                 f"{string_field} should be string",
                 ErrorCode.MESSAGE_VALUE_NOT_STRING
             )
+
+    validate_scene_file(extra_data['scene_file'])

--- a/concent_api/verifier/utils.py
+++ b/concent_api/verifier/utils.py
@@ -145,7 +145,7 @@ def delete_file(file_path: str) -> None:
 
 def generate_full_blender_output_file_name(scene_file: str, frame_number: int, output_format: str) -> str:
     base_blender_output_file_name = generate_base_blender_output_file_name(scene_file)
-    return f'{base_blender_output_file_name}{frame_number:>04}.{output_format}'
+    return f'{base_blender_output_file_name}{frame_number:>04}.{output_format.lower()}'
 
 
 def generate_base_blender_output_file_name(scene_file: str) -> str:
@@ -410,7 +410,7 @@ def render_images_by_frames(
     blender_output_file_name_list = []
     for frame_number in frames:
         render_image(frame_number, output_format, scene_file, subtask_id, verification_deadline, blender_crop_script)
-        blender_out_file_name = generate_full_blender_output_file_name(scene_file, frame_number, output_format.lower())
+        blender_out_file_name = generate_full_blender_output_file_name(scene_file, frame_number, output_format)
         blender_output_file_name_list.append(blender_out_file_name)
         parsed_files_to_compare[frame_number].append(blender_out_file_name)
     return (blender_output_file_name_list, parsed_files_to_compare)


### PR DESCRIPTION
Method tested: 
1. compare_images 
2. generate_verifier_storage_file_path 
3. generate_upload_file_path
4. generate_base_blender_output_file_name,
5. generate_full_blender_output_file_name
6. adjust_format_name

This is part of https://github.com/golemfactory/concent/issues/582 issue