### PR TITLE
Add additional archives validation in verifier

### DIFF
--- a/concent_api/conductor/tests/test_tasks.py
+++ b/concent_api/conductor/tests/test_tasks.py
@@ -1,5 +1,5 @@
 import mock
-from mock import patch
+from freezegun import freeze_time
 from django.conf import settings
 from conductor.models import BlenderSubtaskDefinition
 from conductor.models import VerificationRequest
@@ -53,51 +53,52 @@ class ConductorTaskTestCase(ConcentIntegrationTestCase):
         blender_subtask_definition.save()
 
     def test_that_upload_acknowledged_task_should_change_upload_finished_on_existing_related_verification_request_to_true_and_call_blender_verification_order_task(self):
-        store_subtask(
-            task_id=self.report_computed_task.task_to_compute.compute_task_def['task_id'],
-            subtask_id=self.report_computed_task.task_to_compute.compute_task_def['subtask_id'],
-            provider_public_key=self.PROVIDER_PUBLIC_KEY,
-            requestor_public_key=self.REQUESTOR_PUBLIC_KEY,
-            state=Subtask.SubtaskState.ADDITIONAL_VERIFICATION,
-            next_deadline=get_current_utc_timestamp() + settings.CONCENT_MESSAGING_TIME,
-            task_to_compute=self.report_computed_task.task_to_compute,
-            report_computed_task=self.report_computed_task,
-        )
-
-        with mock.patch('conductor.tasks.blender_verification_order.delay') as mock_blender_verification_order, \
-            mock.patch('conductor.tasks.filter_frames_by_blender_subtask_definition', return_value=[1]) as mock_frames_filtering:  # noqa: E125
-            upload_acknowledged(
-                subtask_id=self.report_computed_task.subtask_id,
-                source_file_size=self.report_computed_task.task_to_compute.size,
-                source_package_hash=self.report_computed_task.task_to_compute.package_hash,
-                result_file_size=self.report_computed_task.size,
-                result_package_hash=self.report_computed_task.package_hash,
+        with freeze_time():
+            store_subtask(
+                task_id=self.report_computed_task.task_to_compute.compute_task_def['task_id'],
+                subtask_id=self.report_computed_task.task_to_compute.compute_task_def['subtask_id'],
+                provider_public_key=self.PROVIDER_PUBLIC_KEY,
+                requestor_public_key=self.REQUESTOR_PUBLIC_KEY,
+                state=Subtask.SubtaskState.ADDITIONAL_VERIFICATION,
+                next_deadline=get_current_utc_timestamp() + settings.CONCENT_MESSAGING_TIME,
+                task_to_compute=self.report_computed_task.task_to_compute,
+                report_computed_task=self.report_computed_task,
             )
 
-        self.verification_request.refresh_from_db()
+            with mock.patch('conductor.tasks.blender_verification_order.delay') as mock_blender_verification_order, \
+                mock.patch('conductor.tasks.filter_frames_by_blender_subtask_definition', return_value=[1]) as mock_frames_filtering:  # noqa: E125
+                upload_acknowledged(
+                    subtask_id=self.report_computed_task.subtask_id,
+                    source_file_size=self.report_computed_task.task_to_compute.size,
+                    source_package_hash=self.report_computed_task.task_to_compute.package_hash,
+                    result_file_size=self.report_computed_task.size,
+                    result_package_hash=self.report_computed_task.package_hash,
+                )
 
-        self.assertTrue(self.verification_request.upload_acknowledged)
-        mock_blender_verification_order.assert_called_once_with(
-            frames=[1],
-            subtask_id=self.verification_request.subtask_id,
-            source_package_path=self.verification_request.source_package_path,
-            source_size=self.report_computed_task.task_to_compute.size,
-            source_package_hash=self.report_computed_task.task_to_compute.package_hash,
-            result_package_path=self.verification_request.result_package_path,
-            result_size=self.report_computed_task.size,
-            result_package_hash=self.report_computed_task.package_hash,
-            output_format=self.verification_request.blender_subtask_definition.output_format,
-            scene_file=self.verification_request.blender_subtask_definition.scene_file,
-            verification_deadline=self._get_verification_deadline_as_timestamp(
-                get_current_utc_timestamp(),
-                self.report_computed_task.task_to_compute,
-            ),
-            blender_crop_script=self.verification_request.blender_subtask_definition.blender_crop_script,
-        )
-        mock_frames_filtering.assert_called_once()
+            self.verification_request.refresh_from_db()
 
-    @patch("conductor.tasks.log_error_message")
-    @patch("conductor.tasks.logger")
+            self.assertTrue(self.verification_request.upload_acknowledged)
+            mock_blender_verification_order.assert_called_once_with(
+                frames=[1],
+                subtask_id=self.verification_request.subtask_id,
+                source_package_path=self.verification_request.source_package_path,
+                source_size=self.report_computed_task.task_to_compute.size,
+                source_package_hash=self.report_computed_task.task_to_compute.package_hash,
+                result_package_path=self.verification_request.result_package_path,
+                result_size=self.report_computed_task.size,
+                result_package_hash=self.report_computed_task.package_hash,
+                output_format=self.verification_request.blender_subtask_definition.output_format,
+                scene_file=self.verification_request.blender_subtask_definition.scene_file,
+                verification_deadline=self._get_verification_deadline_as_timestamp(
+                    get_current_utc_timestamp(),
+                    self.report_computed_task.task_to_compute,
+                ),
+                blender_crop_script=self.verification_request.blender_subtask_definition.blender_crop_script,
+            )
+            mock_frames_filtering.assert_called_once()
+
+    @mock.patch("conductor.tasks.log_error_message")
+    @mock.patch("conductor.tasks.logger")
     def test_that_upload_acknowledged_task_should_log_error_when_verification_request_with_given_subtask_id_does_not_exist(self, mock_logger, mock_logging_error):
         upload_acknowledged(
             subtask_id='non_existing_subtask_id',

--- a/concent_api/core/tests/test_unit_validation.py
+++ b/concent_api/core/tests/test_unit_validation.py
@@ -322,9 +322,9 @@ class TestValidateComputeTaskDef(object):
         assert_that(exception_wrapper.value.error_code).is_equal_to(ErrorCode.MESSAGE_VALUE_NOT_STRING)
 
 
-class TestValidateSceneFile():
+class TestValidateSceneFile:
 
-    def test_that_wrong_scene_file_name_causes_validation_error(self, scene_file='scene_file.png'):
+    def test_that_wrong_scene_file_name_causes_validation_error(self, scene_file='scene_file.png'):  # pylint: disable=no-self-use
         with pytest.raises(ConcentValidationError) as exception_wrapper:
             validate_scene_file(scene_file)
         assert_that(exception_wrapper.value.error_message).contains(f'{scene_file}')

--- a/concent_api/verifier/tasks.py
+++ b/concent_api/verifier/tasks.py
@@ -111,7 +111,7 @@ def blender_verification_order(
         package_paths_to_downloaded_archive_names
     )
 
-    validate_downloaded_archives(subtask_id, package_paths_to_downloaded_archive_names.values())
+    validate_downloaded_archives(subtask_id, package_paths_to_downloaded_archive_names.values(), scene_file)
 
     unpack_archives(package_paths_to_downloaded_archive_names.values(), subtask_id)
 


### PR DESCRIPTION
- if download package is not a valid .zip file, VerificationMismatch is raised
- if there is no scene file among archives' files, VerificationMismatch is raised
- unit tests have been added

resolves: https://github.com/golemfactory/concent/issues/610