### PR TITLE
Fix decorators order for `blender_verification_order` tasak

### DIFF
--- a/concent_api/verifier/tasks.py
+++ b/concent_api/verifier/tasks.py
@@ -36,8 +36,8 @@ logger = logging.getLogger(__name__)
 
 @shared_task
 @provides_concent_feature('verifier')
-@handle_verification_results
 @log_task_errors
+@handle_verification_results
 def blender_verification_order(
     subtask_id: str,
     source_package_path: str,


### PR DESCRIPTION
`log_task_errors` decorator is after `handle_verification_results`, meaning only unhandled/unexpected errors are reported to Sentry via crash.logger

sentry: https://talkback.golem.network/sentry/concent/issues/28905/