### PR TITLE
Add chunk_size parameter for downloading files from cluster

### DIFF
--- a/concent_api/verifier/utils.py
+++ b/concent_api/verifier/utils.py
@@ -71,7 +71,7 @@ def prepare_storage_request_headers(file_transfer_token: message.concents.FileTr
 
 def store_file_from_response_in_chunks(response: requests.Response, file_path: str):
     with open(file_path, 'xb') as f:
-        for chunk in response.iter_content():
+        for chunk in response.iter_content(chunk_size=1000000):
             f.write(chunk)
 
 


### PR DESCRIPTION
Part of https://github.com/golemfactory/concent/issues/714 issue. 
In this issue just adding parameter to `iter_content` function