### PR TITLE
Add script to generating requirements.lock

### DIFF
--- a/concent_api/generate-requirements-lock.sh
+++ b/concent_api/generate-requirements-lock.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+if [[ "$VIRTUAL_ENV" != "" ]]
+then
+    echo "--find-links https://builds.golem.network/simple/pyelliptic" > ${BASH_SOURCE%/*}/requirements.lock
+    pip freeze >> ${BASH_SOURCE%/*}/requirements.lock
+    echo "Done"
+else
+    echo "Script should be run within virtual environment"
+    exit 1
+fi


### PR DESCRIPTION
Resolves https://github.com/golemfactory/concent/issues/711

> `Add [database] to django-constance to make it look like django-constance[database]==2.2.0.` 

It wasn't necessary. I have tested this with installing `django-constance==2.2.0` and it worked with all tests