### PR TITLE
Fix missing comma in pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -13,7 +13,7 @@ ignore=
     .mypy_cache,
     build,
     dist,
-    Signing_Service.egg-info
+    Signing_Service.egg-info,
     Middleman_Protocol.egg-info
 
 # Add files or directories matching the regex patterns to the blacklist. The


### PR DESCRIPTION
There is no issue for this. Just small fix