### PR TITLE
Refactor MiddleMan Protocol: constant from Signig Service to prtocol constants

### DIFF
--- a/middleman_protocol/middleman_protocol/constants.py
+++ b/middleman_protocol/middleman_protocol/constants.py
@@ -63,3 +63,6 @@ MIDDLEMAN_EXCEPTION_TO_ERROR_CODE_MAP = {
     exceptions.FrameInvalidMiddlemanProtocolError: ErrorCode.InvalidFrame,
     exceptions.MiddlemanProtocolError: ErrorCode.Unknown,
 }
+
+# When deserializing message is not possible, response should use following request_id
+REQUEST_ID_FOR_RESPONSE_FOR_INVALID_FRAME = 0

--- a/signing_service/signing_service/constants.py
+++ b/signing_service/signing_service/constants.py
@@ -34,7 +34,4 @@ SIGNING_SERVICE_RECOVERABLE_ERRORS = [
     socket.errno.EHOSTUNREACH,  # type: ignore
 ]
 
-# When deserializing message is not possible, response should use following request_id
-REQUEST_ID_FOR_RESPONSE_FOR_INVALID_FRAME = 0
-
 ETHEREUM_PRIVATE_KEY_REGEXP = re.compile(r'^[a-f0-9]{64}$')

--- a/signing_service/signing_service/signing_service.py
+++ b/signing_service/signing_service/signing_service.py
@@ -18,6 +18,7 @@ from middleman_protocol.concent_golem_messages.message import TransactionRejecte
 from middleman_protocol.concent_golem_messages.message import TransactionSigningRequest
 from middleman_protocol.constants import ErrorCode
 from middleman_protocol.constants import PayloadType
+from middleman_protocol.constants import REQUEST_ID_FOR_RESPONSE_FOR_INVALID_FRAME
 from middleman_protocol.exceptions import FrameInvalidMiddlemanProtocolError
 from middleman_protocol.exceptions import PayloadInvalidMiddlemanProtocolError
 from middleman_protocol.exceptions import PayloadTypeInvalidMiddlemanProtocolError
@@ -29,7 +30,6 @@ from middleman_protocol.message import GolemMessageFrame
 from middleman_protocol.stream import send_over_stream
 from middleman_protocol.stream import unescape_stream
 
-from signing_service.constants import REQUEST_ID_FOR_RESPONSE_FOR_INVALID_FRAME
 from signing_service.constants import SIGNING_SERVICE_DEFAULT_PORT
 from signing_service.constants import SIGNING_SERVICE_DEFAULT_INITIAL_RECONNECT_DELAY  # pylint: disable=no-name-in-module
 from signing_service.constants import SIGNING_SERVICE_MAXIMUM_RECONNECT_TIME

--- a/signing_service/signing_service/tests/test_handle_connection.py
+++ b/signing_service/signing_service/tests/test_handle_connection.py
@@ -14,11 +14,11 @@ from middleman_protocol.constants import FRAME_PAYLOAD_STARTING_BYTE
 from middleman_protocol.constants import FRAME_PAYLOAD_TYPE_LENGTH
 from middleman_protocol.constants import FRAME_REQUEST_ID_BYTES_LENGTH
 from middleman_protocol.constants import FRAME_SIGNATURE_BYTES_LENGTH
+from middleman_protocol.constants import REQUEST_ID_FOR_RESPONSE_FOR_INVALID_FRAME
 from middleman_protocol.message import AbstractFrame
 from middleman_protocol.message import GolemMessageFrame
 from middleman_protocol.stream import unescape_stream
 
-from signing_service.constants import REQUEST_ID_FOR_RESPONSE_FOR_INVALID_FRAME
 from signing_service.exceptions import SigningServiceValidationError
 from signing_service.signing_service import SigningService
 from .utils import SigningServiceIntegrationTestCase


### PR DESCRIPTION
`REQUEST_ID_FOR_RESPONSE_FOR_INVALID_FRAME` constant has been moved