### PR TITLE
Bugfix integration tests error codes fixes

### DIFF
--- a/concent_api/core/message_handlers.py
+++ b/concent_api/core/message_handlers.py
@@ -811,7 +811,7 @@ def handle_send_force_payment(
 
 
 def handle_unsupported_golem_messages_type(client_message):
-    if hasattr(client_message, 'TYPE'):
+    if hasattr(client_message, 'header') and hasattr(client_message.header, 'type_'):
         raise Http400(
             f"This message type ({type(client_message).__name__}) is either not supported or cannot be submitted to Concent.",
             error_code=ErrorCode.MESSAGE_UNEXPECTED,

--- a/concent_api/core/tests/test_auth_accept_or_reject_results.py
+++ b/concent_api/core/tests/test_auth_accept_or_reject_results.py
@@ -121,21 +121,25 @@ class AuthAcceptOrRejectIntegrationTest(ConcentIntegrationTestCase):
                         provider_public_key=self._get_diffrent_provider_hex_public_key(),
                         requestor_public_key=self._get_diffrent_requestor_hex_public_key(),
                         signer_private_key=self.DIFFERENT_REQUESTOR_PRIVATE_KEY,
+                        compute_task_def=task_to_compute.compute_task_def,
                     ),
                     signer_private_key=self.DIFFERENT_PROVIDER_PRIVATE_KEY,
                 ),
                 signer_private_key=self.DIFFERENT_REQUESTOR_PRIVATE_KEY,
-                task_to_compute=task_to_compute
             ),
             provider_private_key=self.DIFFERENT_PROVIDER_PRIVATE_KEY,
         )
 
-        with freeze_time("2018-02-05 10:00:31"):
-            response = self.client.post(
-                reverse('core:send'),
-                data                                = different_serialized_force_subtask_results,
-                content_type                        = 'application/octet-stream',
-            )
+        with mock.patch(
+            'core.message_handlers.payments_service.is_account_status_positive',
+            side_effect=self.is_account_status_positive_true_mock
+        ):
+            with freeze_time("2018-02-05 10:00:31"):
+                response = self.client.post(
+                    reverse('core:send'),
+                    data=different_serialized_force_subtask_results,
+                    content_type='application/octet-stream',
+                )
 
         self._test_response(
             response,
@@ -152,12 +156,16 @@ class AuthAcceptOrRejectIntegrationTest(ConcentIntegrationTestCase):
 
         # STEP 3: Provider again forces subtask results via Concent with message with the same task_id with correct keys.
         # Request is refused.
-        with freeze_time("2018-02-05 10:00:31"):
-            response = self.client.post(
-                reverse('core:send'),
-                data                                = serialized_force_subtask_results,
-                content_type                        = 'application/octet-stream',
-            )
+        with mock.patch(
+            'core.message_handlers.payments_service.is_account_status_positive',
+            side_effect=self.is_account_status_positive_true_mock
+        ):
+            with freeze_time("2018-02-05 10:00:31"):
+                response = self.client.post(
+                    reverse('core:send'),
+                    data=serialized_force_subtask_results,
+                    content_type='application/octet-stream',
+                )
 
         self._test_response(
             response,

--- a/concent_api/core/tests/test_core_views.py
+++ b/concent_api/core/tests/test_core_views.py
@@ -131,6 +131,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             CONCENT_PUBLIC_KEY,
         )
         self.assertIsInstance(response_message, message.concents.ForceReportComputedTaskResponse)
+        self.assertEqual(response_message.reason, message.concents.ForceReportComputedTaskResponse.REASON.SubtaskTimeout)
 
     @freeze_time("2017-11-17 10:00:00")
     def test_send_should_accept_valid_message_with_non_numeric_task_id(self):
@@ -195,10 +196,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             ),
             content_type                        = 'application/octet-stream',
         )
-        self._test_400_response(
-            response,
-            error_code=ErrorCode.MESSAGE_VALUE_BLANK
-        )
+        self._test_400_response(response)
 
         data                                        = message.concents.ForceReportComputedTask()
         data.report_computed_task                   = message.tasks.ReportComputedTask()
@@ -215,6 +213,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             content_type                        = 'application/octet-stream',
         )
         self._test_400_response(response)
+        self.assertTrue(response.json()['error'].startswith('Error in Golem Message'))
 
     @freeze_time("2017-11-17 10:00:00")
     def test_send_should_return_http_400_if_task_id_already_use(self):
@@ -266,7 +265,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
 
         self._test_400_response(
             response_400,
-            error_code=ErrorCode.MESSAGE_UNEXPECTED
+            error_code=ErrorCode.MESSAGE_UNKNOWN
         )
 
     @freeze_time("2017-11-17 10:00:00")

--- a/concent_api/core/tests/test_core_views.py
+++ b/concent_api/core/tests/test_core_views.py
@@ -28,9 +28,6 @@ from common.testing_helpers         import generate_ecc_key_pair
 
 
 (CONCENT_PRIVATE_KEY,   CONCENT_PUBLIC_KEY)   = generate_ecc_key_pair()
-(PROVIDER_PRIVATE_KEY,  PROVIDER_PUBLIC_KEY)  = generate_ecc_key_pair()
-(REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY) = generate_ecc_key_pair()
-(DIFFERENT_PRIVATE_KEY, DIFFERENT_PUBLIC_KEY) = generate_ecc_key_pair()
 
 
 @override_settings(
@@ -84,7 +81,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             reverse('core:send'),
             data = dump(
                 self.correct_golem_data,
-                PROVIDER_PRIVATE_KEY,
+                self.PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY),
             content_type                        = 'application/octet-stream',
         )
@@ -172,12 +169,11 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
 
     @freeze_time("2017-11-17 10:00:00")
     def test_send_should_return_http_400_if_data_is_incorrect(self):
-        compute_task_def    = message.ComputeTaskDef()
-        task_to_compute     = message.TaskToCompute(
-            compute_task_def     = compute_task_def,
-            provider_public_key  = PROVIDER_PUBLIC_KEY,
-            requestor_public_key = REQUESTOR_PUBLIC_KEY,
-            price=0,
+        compute_task_def = message.ComputeTaskDef()
+        task_to_compute = message.TaskToCompute(
+            compute_task_def=compute_task_def,
+            provider_public_key=self._get_encoded_provider_public_key(),
+            requestor_public_key=self._get_encoded_requestor_public_key(),
         )
         report_computed_task = message.tasks.ReportComputedTask(
             task_to_compute = task_to_compute
@@ -191,7 +187,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             reverse('core:send'),
             data = dump(
                 force_report_computed_task,
-                PROVIDER_PRIVATE_KEY,
+                self.PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type                        = 'application/octet-stream',
@@ -207,7 +203,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             reverse('core:send'),
             data = dump(
                 data,
-                PROVIDER_PRIVATE_KEY,
+                self.PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type                        = 'application/octet-stream',
@@ -222,7 +218,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             reverse('core:send'),
             data = dump(
                 self.correct_golem_data,
-                PROVIDER_PRIVATE_KEY,
+                self.PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type                        = 'application/octet-stream',
@@ -236,7 +232,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             reverse('core:send'),
             data = dump(
                 self.correct_golem_data,
-                PROVIDER_PRIVATE_KEY,
+                self.PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY,
             ),
             content_type                        = 'application/octet-stream',
@@ -257,7 +253,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             reverse('core:send'),
             data = dump(
                 self.want_to_compute,
-                PROVIDER_PRIVATE_KEY,
+                self.PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY
             ),
             content_type                   = 'application/octet-stream',
@@ -275,25 +271,27 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
 
         with freeze_time(datetime.datetime.fromtimestamp(self.message_timestamp - 10000)):
             task_to_compute = tasks.TaskToComputeFactory(
-                compute_task_def     = self.compute_task_def,
-                provider_public_key  = PROVIDER_PUBLIC_KEY,
-                requestor_public_key = REQUESTOR_PUBLIC_KEY,
-                price=0,
+                compute_task_def=self.compute_task_def,
+                provider_public_key=self._get_provider_hex_public_key(),
+                requestor_public_key=self._get_requestor_hex_public_key(),
             )
 
-        serialized_task_to_compute      = dump(task_to_compute,             REQUESTOR_PRIVATE_KEY,   PROVIDER_PUBLIC_KEY)
-        deserialized_task_to_compute    = load(serialized_task_to_compute,  PROVIDER_PRIVATE_KEY,  REQUESTOR_PUBLIC_KEY, check_time = False)
+        task_to_compute.sign_message(self.REQUESTOR_PRIVATE_KEY)
 
-        ack_report_computed_task = message.tasks.AckReportComputedTask()
-        ack_report_computed_task.report_computed_task = message.ReportComputedTask(
-            task_to_compute = deserialized_task_to_compute
+        report_computed_task = message.ReportComputedTask(
+            task_to_compute=task_to_compute
+        )
+        report_computed_task.sign_message(self.PROVIDER_PRIVATE_KEY)
+
+        ack_report_computed_task = message.tasks.AckReportComputedTask(
+            report_computed_task=report_computed_task
         )
 
         response_400 = self.client.post(
             reverse('core:send'),
             data = dump(
                 ack_report_computed_task,
-                PROVIDER_PRIVATE_KEY,
+                self.PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY
             ),
             content_type                    = 'application/octet-stream',
@@ -316,7 +314,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             reverse('core:send'),
             data = dump(
                 self.correct_golem_data,
-                PROVIDER_PRIVATE_KEY,
+                self.PROVIDER_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY),
             content_type                        = 'application/octet-stream',
         )
@@ -335,7 +333,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             reverse('core:send'),
             data = dump(
                 self.reject_report_computed_task,
-                REQUESTOR_PRIVATE_KEY,
+                self.REQUESTOR_PRIVATE_KEY,
                 CONCENT_PUBLIC_KEY
             ),
             content_type                   = 'application/octet-stream',
@@ -361,7 +359,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
                 reverse('core:send'),
                 data = dump(
                     ping,
-                    PROVIDER_PRIVATE_KEY,
+                    self.PROVIDER_PRIVATE_KEY,
                     CONCENT_PUBLIC_KEY
                 ),
                 content_type                   = 'application/octet-stream',
@@ -380,7 +378,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
                 reverse('core:send'),
                 data = dump(
                     ping,
-                    PROVIDER_PRIVATE_KEY,
+                    self.PROVIDER_PRIVATE_KEY,
                     CONCENT_PUBLIC_KEY
                 ),
                 content_type                   = 'application/octet-stream',
@@ -405,14 +403,13 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
             StoredMessage.objects.all().delete()
             compute_task_def['deadline'] = deadline
             task_to_compute = tasks.TaskToComputeFactory(
-                compute_task_def     = compute_task_def,
-                provider_public_key  = PROVIDER_PUBLIC_KEY,
-                requestor_public_key = REQUESTOR_PUBLIC_KEY,
-                price=0,
+                compute_task_def=compute_task_def,
+                provider_public_key=self._get_provider_hex_public_key(),
+                requestor_public_key=self._get_requestor_hex_public_key(),
             )
 
-            serialized_task_to_compute   = dump(task_to_compute,             REQUESTOR_PRIVATE_KEY,   PROVIDER_PUBLIC_KEY)
-            deserialized_task_to_compute = load(serialized_task_to_compute,  PROVIDER_PRIVATE_KEY,  REQUESTOR_PUBLIC_KEY, check_time = False)
+            serialized_task_to_compute   = dump(task_to_compute, self.REQUESTOR_PRIVATE_KEY, self.PROVIDER_PUBLIC_KEY)
+            deserialized_task_to_compute = load(serialized_task_to_compute, self.PROVIDER_PRIVATE_KEY, self.REQUESTOR_PUBLIC_KEY, check_time = False)
 
             with freeze_time("2017-11-17 10:00:00"):
                 force_report_computed_task = message.concents.ForceReportComputedTask(
@@ -425,7 +422,7 @@ class CoreViewSendTest(ConcentIntegrationTestCase):
                     reverse('core:send'),
                     data=dump(
                         force_report_computed_task,
-                        PROVIDER_PRIVATE_KEY,
+                        self.PROVIDER_PRIVATE_KEY,
                         CONCENT_PUBLIC_KEY
                     ),
                     content_type = 'application/octet-stream',
@@ -563,9 +560,8 @@ class CoreViewReceiveTest(ConcentIntegrationTestCase):
             self.compute_task_def['deadline'] = get_current_utc_timestamp() + (60 * 37)
             self.task_to_compute = tasks.TaskToComputeFactory(
                 compute_task_def=self.compute_task_def,
-                provider_public_key=PROVIDER_PUBLIC_KEY,
-                requestor_public_key=REQUESTOR_PUBLIC_KEY,
-                price=0,
+                provider_public_key=self._get_provider_hex_public_key(),
+                requestor_public_key=self._get_requestor_hex_public_key(),
             )
             self.size = 58
             self.force_golem_data = message.concents.ForceReportComputedTask(
@@ -589,13 +585,13 @@ class CoreViewReceiveTest(ConcentIntegrationTestCase):
         new_message.save()
 
         client_provider = Client(
-            public_key_bytes = PROVIDER_PUBLIC_KEY
+            public_key_bytes=self.PROVIDER_PUBLIC_KEY
         )
         client_provider.full_clean()
         client_provider.save()
 
         client_requestor = Client(
-            public_key_bytes = REQUESTOR_PUBLIC_KEY
+            public_key_bytes=self.REQUESTOR_PUBLIC_KEY
         )
         client_requestor.full_clean()
         client_requestor.save()
@@ -636,11 +632,11 @@ class CoreViewReceiveTest(ConcentIntegrationTestCase):
         response = self.client.post(
             reverse('core:receive'),
             content_type                   = 'application/octet-stream',
-            data                           = self._create_client_auth_message(REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY),
+            data                           = self._create_client_auth_message(self.REQUESTOR_PRIVATE_KEY, self.REQUESTOR_PUBLIC_KEY),
         )
         decoded_response = load(
             response.content,
-            REQUESTOR_PRIVATE_KEY,
+            self.REQUESTOR_PRIVATE_KEY,
             CONCENT_PUBLIC_KEY,
         )
         self.assertEqual(response.status_code,   200)
@@ -651,7 +647,7 @@ class CoreViewReceiveTest(ConcentIntegrationTestCase):
     def test_receive_return_http_204_if_no_messages_in_database(self):
         response = self.client.post(
             reverse('core:receive'),
-            data                           = self._create_client_auth_message(REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY),
+            data                           = self._create_client_auth_message(self.REQUESTOR_PRIVATE_KEY, self.REQUESTOR_PUBLIC_KEY),
             content_type                   = 'application/octet-stream',
         )
 
@@ -664,9 +660,8 @@ class CoreViewReceiveTest(ConcentIntegrationTestCase):
             self.compute_task_def['deadline'] = get_current_utc_timestamp()
             self.task_to_compute = message.TaskToCompute(
                 compute_task_def=self.compute_task_def,
-                provider_public_key=PROVIDER_PUBLIC_KEY,
-                requestor_public_key=REQUESTOR_PUBLIC_KEY,
-                price=0,
+                provider_public_key=self._get_encoded_provider_public_key(),
+                requestor_public_key=self._get_encoded_requestor_public_key(),
             )
             self.force_golem_data = message.concents.ForceReportComputedTask(
                 report_computed_task=message.tasks.ReportComputedTask(
@@ -713,13 +708,13 @@ class CoreViewReceiveTest(ConcentIntegrationTestCase):
         stored_ack_report_computed_task.save()
 
         client_provider = Client(
-            public_key_bytes = PROVIDER_PUBLIC_KEY
+            public_key_bytes=self.PROVIDER_PUBLIC_KEY
         )
         client_provider.full_clean()
         client_provider.save()
 
         client_requestor = Client(
-            public_key_bytes = REQUESTOR_PUBLIC_KEY
+            public_key_bytes=self.REQUESTOR_PUBLIC_KEY
         )
         client_requestor.full_clean()
         client_requestor.save()
@@ -761,12 +756,12 @@ class CoreViewReceiveTest(ConcentIntegrationTestCase):
             response = self.client.post(
                 reverse('core:receive'),
                 content_type                   = 'application/octet-stream',
-                data                           = self._create_client_auth_message(REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY),
+                data                           = self._create_client_auth_message(self.REQUESTOR_PRIVATE_KEY, self.REQUESTOR_PUBLIC_KEY),
             )
 
         decoded_message = load(
             response.content,
-            REQUESTOR_PRIVATE_KEY,
+            self.REQUESTOR_PRIVATE_KEY,
             CONCENT_PUBLIC_KEY,
             check_time = False,
         )
@@ -781,12 +776,12 @@ class CoreViewReceiveTest(ConcentIntegrationTestCase):
             response = self.client.post(
                 reverse('core:receive_out_of_band'),
                 content_type                   = 'application/octet-stream',
-                data                           = self._create_client_auth_message(REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY),
+                data                           = self._create_client_auth_message(self.REQUESTOR_PRIVATE_KEY, self.REQUESTOR_PUBLIC_KEY),
             )
 
         decoded_message = load(
             response.content,
-            REQUESTOR_PRIVATE_KEY,
+            self.REQUESTOR_PRIVATE_KEY,
             CONCENT_PUBLIC_KEY,
             check_time = False,
         )
@@ -808,12 +803,11 @@ class CoreViewReceiveOutOfBandTest(ConcentIntegrationTestCase):
     def setUp(self):
         super().setUp()
         self.compute_task_def = ComputeTaskDefFactory()
-        self.compute_task_def['deadline']   = get_current_utc_timestamp() - 60
-        self.task_to_compute                = tasks.TaskToComputeFactory(
-            compute_task_def     = self.compute_task_def,
-            provider_public_key  = PROVIDER_PUBLIC_KEY,
-            requestor_public_key = REQUESTOR_PUBLIC_KEY,
-            price=0,
+        self.compute_task_def['deadline'] = get_current_utc_timestamp() - 60
+        self.task_to_compute = tasks.TaskToComputeFactory(
+            compute_task_def=self.compute_task_def,
+            provider_public_key=self._get_provider_hex_public_key(),
+            requestor_public_key=self._get_requestor_hex_public_key(),
         )
         self.size = 58
 
@@ -862,13 +856,13 @@ class CoreViewReceiveOutOfBandTest(ConcentIntegrationTestCase):
         stored_ack_report_computed_task.save()
 
         client_provider = Client(
-            public_key_bytes = PROVIDER_PUBLIC_KEY
+            public_key_bytes = self.PROVIDER_PUBLIC_KEY
         )
         client_provider.full_clean()
         client_provider.save()
 
         client_requestor = Client(
-            public_key_bytes = REQUESTOR_PUBLIC_KEY
+            public_key_bytes = self.REQUESTOR_PUBLIC_KEY
         )
         client_requestor.full_clean()
         client_requestor.save()
@@ -902,7 +896,7 @@ class CoreViewReceiveOutOfBandTest(ConcentIntegrationTestCase):
 
         response = self.client.post(
             reverse('core:receive_out_of_band'),
-            data                                = self._create_client_auth_message(REQUESTOR_PRIVATE_KEY, REQUESTOR_PUBLIC_KEY),
+            data                                = self._create_client_auth_message(self.REQUESTOR_PRIVATE_KEY, self.REQUESTOR_PUBLIC_KEY),
             content_type                        = 'application/octet-stream',
         )
 
@@ -912,7 +906,7 @@ class CoreViewReceiveOutOfBandTest(ConcentIntegrationTestCase):
     def test_view_receive_out_of_band_return_http_204_if_no_messages_in_database(self):
         response = self.client.post(
             reverse('core:receive_out_of_band'),
-            data                                = self._create_client_auth_message(DIFFERENT_PRIVATE_KEY, DIFFERENT_PUBLIC_KEY),
+            data                                = self._create_client_auth_message(self.DIFFERENT_REQUESTOR_PRIVATE_KEY, self.DIFFERENT_REQUESTOR_PUBLIC_KEY),
             content_type                        = 'application/octet-stream',
         )
 

--- a/concent_api/core/tests/test_integration_accept_or_reject_results.py
+++ b/concent_api/core/tests/test_integration_accept_or_reject_results.py
@@ -1668,16 +1668,18 @@ class AcceptOrRejectIntegrationTest(ConcentIntegrationTestCase):
             )
         )
 
+        subtask_id = self._get_uuid()
+
         compute_task_def = self._get_deserialized_compute_task_def(
-            task_id     = '2',
-            deadline    = "2018-02-05 11:00:00",
+            subtask_id=subtask_id,
+            deadline="2018-02-05 11:00:00",
         )
 
         task_to_compute = deserialized_force_subtask_results.ack_report_computed_task.report_computed_task.task_to_compute  # pylint: disable=no-member,
 
         subtask = store_or_update_subtask(
             task_id=task_to_compute.compute_task_def['task_id'],
-            subtask_id=task_to_compute.compute_task_def['subtask_id'],
+            subtask_id=subtask_id,
             provider_public_key=self.PROVIDER_PUBLIC_KEY,
             requestor_public_key=self.REQUESTOR_PUBLIC_KEY,
             state=Subtask.SubtaskState.ACCEPTED,
@@ -1734,6 +1736,7 @@ class AcceptOrRejectIntegrationTest(ConcentIntegrationTestCase):
                     task_to_compute = self._get_deserialized_task_to_compute(
                         timestamp   = "2018-02-05 11:00:01",
                         deadline    = "2018-02-05 11:00:06",
+                        compute_task_def=compute_task_def,
                     )
                 )
             )
@@ -1776,15 +1779,18 @@ class AcceptOrRejectIntegrationTest(ConcentIntegrationTestCase):
             )
         )
 
+        subtask_id = self._get_uuid()
+
         compute_task_def = self._get_deserialized_compute_task_def(
-            deadline    = "2018-02-05 11:00:00",
+            deadline="2018-02-05 11:00:00",
+            subtask_id=subtask_id,
         )
 
         task_to_compute = deserialized_force_subtask_results.ack_report_computed_task.report_computed_task.task_to_compute  # pylint: disable=no-member,
 
         subtask = store_or_update_subtask(
             task_id=task_to_compute.compute_task_def['task_id'],
-            subtask_id=task_to_compute.compute_task_def['subtask_id'],
+            subtask_id=subtask_id,
             provider_public_key=self.PROVIDER_PUBLIC_KEY,
             requestor_public_key=self.REQUESTOR_PUBLIC_KEY,
             state=Subtask.SubtaskState.ACCEPTED,
@@ -1835,6 +1841,7 @@ class AcceptOrRejectIntegrationTest(ConcentIntegrationTestCase):
                     task_to_compute = self._get_deserialized_task_to_compute(
                         timestamp   = "2018-02-05 11:00:01",
                         deadline    = "2018-02-05 11:00:06",
+                        compute_task_def=compute_task_def,
                     )
                 )
             )
@@ -1878,7 +1885,7 @@ class AcceptOrRejectIntegrationTest(ConcentIntegrationTestCase):
 
         self._test_400_response(
             response_1,
-            error_code=ErrorCode.MESSAGE_UNEXPECTED
+            error_code=ErrorCode.MESSAGE_INVALID
         )
         self._assert_stored_message_counter_not_increased()
 

--- a/concent_api/core/tests/test_integration_report_computed_task.py
+++ b/concent_api/core/tests/test_integration_report_computed_task.py
@@ -1082,7 +1082,7 @@ class ReportComputedTaskIntegrationTest(ConcentIntegrationTestCase):
 
         # STEP 4: Requestor rejects computed task via Concent
         reject_report_computed_task = self._get_deserialized_reject_report_computed_task(
-            reason=None,
+            reason=message.tasks.RejectReportComputedTask.REASON.SubtaskTimeLimitExceeded,
             timestamp           = "2017-12-01 11:00:05",
             task_to_compute=task_to_compute,
         )
@@ -1695,7 +1695,7 @@ class ReportComputedTaskIntegrationTest(ConcentIntegrationTestCase):
             )
         self._test_400_response(
             response_1,
-            error_code=ErrorCode.MESSAGE_VALUE_WRONG_TYPE,
+            error_code=ErrorCode.MESSAGE_VALUE_WRONG_LENGTH,
         )
         self._assert_stored_message_counter_not_increased()
 
@@ -1745,7 +1745,7 @@ class ReportComputedTaskIntegrationTest(ConcentIntegrationTestCase):
             )
         self._test_400_response(
             response_1,
-            error_code=ErrorCode.MESSAGE_VALUE_WRONG_TYPE
+            error_code=ErrorCode.MESSAGE_VALUE_WRONG_LENGTH
         )
         self._assert_stored_message_counter_not_increased()
 
@@ -1795,7 +1795,7 @@ class ReportComputedTaskIntegrationTest(ConcentIntegrationTestCase):
             )
         self._test_400_response(
             response_1,
-            error_code=ErrorCode.MESSAGE_VALUE_WRONG_TYPE,
+            error_code=ErrorCode.MESSAGE_VALUE_WRONG_LENGTH,
         )
         self._assert_stored_message_counter_not_increased()
 

--- a/concent_api/core/tests/utils.py
+++ b/concent_api/core/tests/utils.py
@@ -169,8 +169,8 @@ class ConcentIntegrationTestCase(TestCase):
 
     def _get_deserialized_report_computed_task(
         self,
-        subtask_id: str = str(uuid.uuid4()),
-        task_id: str = str(uuid.uuid4()),
+        subtask_id: Optional[str] = None,
+        task_id: Optional[str] = None,
         task_to_compute: Optional[TaskToCompute] = None,
         size: int = 1,
         package_hash: str = 'sha1:4452d71687b6bc2c9389c3349fdc17fbd73b833b',
@@ -184,8 +184,8 @@ class ConcentIntegrationTestCase(TestCase):
             report_computed_task = ReportComputedTaskFactory(
                 task_to_compute=(
                     task_to_compute or self._get_deserialized_task_to_compute(
-                        subtask_id=subtask_id,
-                        task_id=task_id,
+                        subtask_id=subtask_id if subtask_id is not None else self._get_uuid(),
+                        task_id=task_id if task_id is not None else self._get_uuid(),
                         frames=frames if frames is not None else [1]
                     )
                 ),
@@ -202,8 +202,8 @@ class ConcentIntegrationTestCase(TestCase):
         self,
         timestamp: Union[str, datetime.datetime, None] = None,
         deadline: Union[str, int, None] = None,
-        task_id: str = str(uuid.uuid4()),
-        subtask_id: str = str(uuid.uuid4()),
+        task_id: Optional[str] = None,
+        subtask_id: Optional[str] = None,
         compute_task_def: Optional[ComputeTaskDef] = None,
         requestor_id: Optional[bytes] = None,
         requestor_public_key: Optional[bytes] = None,
@@ -221,8 +221,8 @@ class ConcentIntegrationTestCase(TestCase):
         """ Returns TaskToCompute deserialized. """
         compute_task_def = (
             compute_task_def if compute_task_def is not None else self._get_deserialized_compute_task_def(
-                task_id=task_id,
-                subtask_id=subtask_id,
+                task_id=task_id if task_id is not None else self._get_uuid(),
+                subtask_id=subtask_id if subtask_id is not None else self._get_uuid(),
                 deadline=deadline,
                 frames=frames if frames is not None else [1],
             )
@@ -269,7 +269,7 @@ class ConcentIntegrationTestCase(TestCase):
         task_to_compute: TaskToCompute,
         timestamp: Union[str, datetime.datetime, None] = None,
         deadline: Union[str, int, None] = None,
-        subtask_id: str = str(uuid.uuid4()),
+        subtask_id: Optional[str] = None,
         report_computed_task: Optional[ReportComputedTask] = None,
         signer_private_key: Optional[bytes] = None,
     )-> AckReportComputedTask:
@@ -283,7 +283,7 @@ class ConcentIntegrationTestCase(TestCase):
                             self._get_deserialized_task_to_compute(
                                 timestamp = timestamp,
                                 deadline  = deadline,
-                                subtask_id=subtask_id
+                                subtask_id=subtask_id if subtask_id is not None else self._get_uuid()
                             )
                         ),
                     )
@@ -582,8 +582,8 @@ class ConcentIntegrationTestCase(TestCase):
 
     def _get_deserialized_compute_task_def(  # pylint: disable=no-self-use
         self,
-        task_id: str = str(uuid.uuid4()),
-        subtask_id: str = str(uuid.uuid4()),
+        task_id: Optional[str] = None,
+        subtask_id: Optional[str] = None,
         deadline: Union[str, int, None] = None,
         extra_data: Optional[dict] = None,
         short_description: str = 'path_root: /home/dariusz/Documents/tasks/resources, start_task: 6, end_task: 6...',
@@ -593,8 +593,8 @@ class ConcentIntegrationTestCase(TestCase):
         frames: Optional[List[int]] = None
     ) -> ComputeTaskDef:
         compute_task_def = ComputeTaskDefFactory(
-            task_id=task_id,
-            subtask_id=subtask_id,
+            task_id=task_id if task_id is not None else self._get_uuid(),
+            subtask_id=subtask_id if subtask_id is not None else self._get_uuid(),
             extra_data=extra_data,
             short_description=short_description,
             working_directory=working_directory,
@@ -950,3 +950,7 @@ class ConcentIntegrationTestCase(TestCase):
             task_to_compute.compute_task_def['deadline'],
             task_to_compute.timestamp,
         )
+
+    @staticmethod
+    def _get_uuid() -> str:
+        return str(uuid.uuid4())

--- a/concent_api/core/tests/utils.py
+++ b/concent_api/core/tests/utils.py
@@ -266,7 +266,7 @@ class ConcentIntegrationTestCase(TestCase):
 
     def _get_deserialized_ack_report_computed_task(
         self,
-        task_to_compute: TaskToCompute,
+        task_to_compute: Optional[TaskToCompute] = None,
         timestamp: Union[str, datetime.datetime, None] = None,
         deadline: Union[str, int, None] = None,
         subtask_id: Optional[str] = None,
@@ -318,6 +318,7 @@ class ConcentIntegrationTestCase(TestCase):
         self.assertIn('error', response.json())
         if error_message is not None:
             self.assertIn(error_message, response.json()['error'])
+        if error_code is not None:
             self.assertEqual(response.json()['error_code'], error_code.value)
 
     def _test_response(self, response, status, key, message_type=None, fields=None, nested_message_verifiable_by=None):


### PR DESCRIPTION
Resolves:
1. There was a bug in `tests.utils._test_400_response` method that causes passed `error_code` parameter not being tested if `error_message` is None. This cause several tests to have wrong error code tested but they were still passing.
2. Golem messages no longer hat `TYPE` attribute so fix to `core.message_handlers.handle_unsupported_golem_messages_type` was required.
3. In `core.tests.test_core_views` provider and requestor keys were passed in wrong formats to TaskToCompute, which failed requests on different validations that were expected by tests, but tests were still passing.