### PR TITLE
Remove fail for any Error and add fail only for system check

### DIFF
--- a/full-check.sh
+++ b/full-check.sh
@@ -1,9 +1,13 @@
-#!/bin/bash -e
+#!/bin/bash
 
 printf "=================== DJANGO CONFIGURATION CHECKS ====================\n"
 python3 concent_api/manage.py check
-printf "\n"
 
+if [ $? != 0 ]; then
+    echo 'Exiting because of System Check error'
+    exit 1
+fi
+printf "\n"
 printf "=============================== LINT ===============================\n"
 ./lint.sh
 printf "\n"


### PR DESCRIPTION
Resolves https://github.com/golemfactory/concent/issues/763

Second pull request, full_check should fail only if System check fails, not because of e.g. Mypy. It is fix to https://github.com/golemfactory/concent/pull/893