### PR TITLE
Feature blockchain event subsciption

### DIFF
--- a/concent_api/core/payments/bankster.py
+++ b/concent_api/core/payments/bankster.py
@@ -479,7 +479,9 @@ def discard_claim(deposit_claim: DepositClaim) -> bool:
         if deposit_claim.tx_hash is None:
             claim_removed = False
         else:
-            deposit_claim.delete()
-            claim_removed = True
-
+            try:
+                deposit_claim.delete()
+                claim_removed = True
+            except DepositAccount.DoesNotExist:
+                claim_removed = False
     return claim_removed

--- a/concent_api/core/tests/test_payments_bankster.py
+++ b/concent_api/core/tests/test_payments_bankster.py
@@ -1,3 +1,4 @@
+
 from freezegun import freeze_time
 import mock
 
@@ -401,3 +402,15 @@ class DiscardClaimBanksterTest(ConcentIntegrationTestCase):
 
         self.assertTrue(claim_removed)
         self.assertFalse(DepositClaim.objects.filter(pk=self.deposit_claim.pk).exists())
+
+    def test_that_discard_claim_should_work_correctly_in_parallel(self):
+        self.deposit_claim.tx_hash = 64 * '0'
+        self.deposit_claim.clean()
+        self.deposit_claim.save()
+
+        from api_testing_common import call_function_in_threads
+        call_function_in_threads(
+            func=discard_claim,
+            number_of_threads=2,
+            deposit_claim=self.deposit_claim
+        )


### PR DESCRIPTION
Resolves https://github.com/golemfactory/concent/issues/899

Please check careful this pull request, the main part is to add callback in `finalize_deposit_claim`. It is not possible to test it local and without @kbeker I don't think we can test it with blockchain.  

There is also added test for function removing deposit_claim. But this function actually checks if object exists in database and calls other function, which is tested. I would remove this (my) test, but please comment 