### PR TITLE
Switch timestamp parser in test_unit_admin_tags.py

### DIFF
--- a/concent_api/core/tests/test_unit_admin_tags.py
+++ b/concent_api/core/tests/test_unit_admin_tags.py
@@ -4,12 +4,12 @@ from freezegun import freeze_time
 from golem_messages.message.concents import ForceGetTaskResult
 from golem_messages.factories.tasks import ReportComputedTaskFactory
 from common.helpers import get_current_utc_timestamp
+from common.helpers import parse_timestamp_to_utc_datetime
 from core.message_handlers import store_subtask
 from core.models import Subtask
 from core.templatetags.admin_tags import get_longest_lasting_subtask_timestamp, get_time_until_concent_can_be_shut_down
 from core.tests.utils import ConcentIntegrationTestCase
 from core.utils import hex_to_bytes_convert
-from api_testing_common import timestamp_to_isoformat
 
 
 class TestAdminTagsQuerySet(ConcentIntegrationTestCase):
@@ -23,7 +23,7 @@ class TestAdminTagsQuerySet(ConcentIntegrationTestCase):
             subtask_id=subtask_id,
             deadline=deadline,
             price=0,
-            timestamp=timestamp_to_isoformat(current_time),
+            timestamp=parse_timestamp_to_utc_datetime(current_time),
         )
         report_computed_task = ReportComputedTaskFactory(
             task_to_compute=task_to_compute,


### PR DESCRIPTION
It fix bug in deployment send by @bartoszbetka :
```
======================================================================
ERROR: core.tests.test_unit_admin_tags (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: core.tests.test_unit_admin_tags
Traceback (most recent call last):
 File "/usr/lib/python3.6/unittest/loader.py", line 428, in _find_test_path
   module = self._get_module_from_name(name)
 File "/usr/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
   __import__(name)
 File "/srv/http/concent_api/core/tests/test_unit_admin_tags.py", line 12, in <module>
   from api_testing_common import timestamp_to_isoformat
 File "/srv/http/concent_api/api_testing_common.py", line 35, in <module>
   from concent_api.settings import GOLEM_MESSAGES_VERSION
ImportError: cannot import name 'GOLEM_MESSAGES_VERSION'
```