### PR TITLE
Fix for Bankster that SCI calls returns transaction hash instead of t…

### DIFF
--- a/concent_api/core/payments/backends/mock.py
+++ b/concent_api/core/payments/backends/mock.py
@@ -1,7 +1,6 @@
 import uuid
 
 from core.constants import CLIENT_ETH_ADDRESS_WITH_0_DEPOSIT
-from core.constants import MOCK_TRANSACTION_HASH
 from core.payments.backends.sci_backend import TransactionType
 
 
@@ -21,7 +20,7 @@ def make_force_payment_to_provider(
     value: int,  # pylint: disable=unused-argument
     payment_ts: int,  # pylint: disable=unused-argument
 ) -> str:
-    return f'{uuid.uuid4()}{uuid.uuid4()}'[:64]
+    return f'{uuid.uuid4()}{uuid.uuid4()}'[:64].replace('-', '1')
 
 
 def get_transaction_count() -> int:
@@ -41,7 +40,7 @@ def force_subtask_payment(
     value: int,  # pylint: disable=unused-argument
     subtask_id: str,  # pylint: disable=unused-argument
 ) -> str:
-    return MOCK_TRANSACTION_HASH
+    return f'{uuid.uuid4()}{uuid.uuid4()}'[:64].replace('-', '1')
 
 
 def cover_additional_verification_cost(
@@ -49,4 +48,4 @@ def cover_additional_verification_cost(
     value: int,  # pylint: disable=unused-argument
     subtask_id: str,  # pylint: disable=unused-argument
 ) -> str:
-    return MOCK_TRANSACTION_HASH
+    return f'{uuid.uuid4()}{uuid.uuid4()}'[:64].replace('-', '1')

--- a/concent_api/core/payments/service.py
+++ b/concent_api/core/payments/service.py
@@ -72,7 +72,7 @@ def force_subtask_payment(
     provider_eth_address: str,
     value: int,
     subtask_id: str,
-) -> Transaction:
+) -> str:
     return backend.force_subtask_payment(
         requestor_eth_address=requestor_eth_address,
         provider_eth_address=provider_eth_address,

--- a/concent_api/core/tests/test_payments_bankster.py
+++ b/concent_api/core/tests/test_payments_bankster.py
@@ -8,7 +8,7 @@ from golem_messages.utils import encode_hex
 
 from common.constants import ConcentUseCase
 from common.helpers import ethereum_public_key_to_address
-from core.constants import MOCK_TRANSACTION
+from core.constants import MOCK_TRANSACTION_HASH
 from core.exceptions import BanksterTimestampError
 from core.exceptions import TooSmallProviderDeposit
 from core.message_handlers import store_subtask
@@ -187,9 +187,9 @@ class FinalizePaymentBanksterTest(ConcentIntegrationTestCase):
 
     def test_that_when_deposit_claim_is_for_forced_acceptance_use_case_finalize_payment_should_call_force_subtask_payment(self):
         with mock.patch('core.payments.service.get_deposit_value', return_value=2) as get_deposit_value:
-            with mock.patch('core.payments.service.force_subtask_payment', return_value=MOCK_TRANSACTION) as force_subtask_payment:
+            with mock.patch('core.payments.service.force_subtask_payment', return_value=MOCK_TRANSACTION_HASH) as force_subtask_payment:
                 returned_value = finalize_payment(self.deposit_claim)
-        self.assertEqual(returned_value, encode_hex(MOCK_TRANSACTION.hash))
+        self.assertEqual(returned_value, MOCK_TRANSACTION_HASH)
 
         get_deposit_value.assert_called_with(
             client_eth_address=self.deposit_claim.payer_deposit_account.ethereum_address,
@@ -207,10 +207,10 @@ class FinalizePaymentBanksterTest(ConcentIntegrationTestCase):
         self.deposit_claim.save()
 
         with mock.patch('core.payments.service.get_deposit_value', return_value=2) as get_deposit_value:
-            with mock.patch('core.payments.service.force_subtask_payment', return_value=MOCK_TRANSACTION) as force_subtask_payment:
+            with mock.patch('core.payments.service.force_subtask_payment', return_value=MOCK_TRANSACTION_HASH) as force_subtask_payment:
                 returned_value = finalize_payment(self.deposit_claim)
 
-        self.assertEqual(returned_value, encode_hex(MOCK_TRANSACTION.hash))
+        self.assertEqual(returned_value, MOCK_TRANSACTION_HASH)
 
         get_deposit_value.assert_called_with(
             client_eth_address=self.deposit_claim.payer_deposit_account.ethereum_address,
@@ -237,10 +237,10 @@ class FinalizePaymentBanksterTest(ConcentIntegrationTestCase):
         self.deposit_claim.save()
 
         with mock.patch('core.payments.service.get_deposit_value', return_value=5) as get_deposit_value:
-            with mock.patch('core.payments.service.force_subtask_payment', return_value=MOCK_TRANSACTION) as force_subtask_payment:
+            with mock.patch('core.payments.service.force_subtask_payment', return_value=MOCK_TRANSACTION_HASH) as force_subtask_payment:
                 returned_value = finalize_payment(self.deposit_claim)
 
-        self.assertEqual(returned_value, encode_hex(MOCK_TRANSACTION.hash))
+        self.assertEqual(returned_value, MOCK_TRANSACTION_HASH)
 
         get_deposit_value.assert_called_with(
             client_eth_address=self.deposit_claim.payer_deposit_account.ethereum_address,


### PR DESCRIPTION
…ransaction object

Fix for Bankster that SCI calls returns transaction hash instead of transaction object.