### PR TITLE
SigningService: Handle wrongly encoded Ethereum public key

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,7 @@
+### Next
+#### Signing Service
+- Bugfix: Catch exception when `ethereum-private-key` is badly encoded and raise custom exception.
+
 ### 0.11.0
 #### Compatibility
 - golem-messages: 2.24.2

--- a/signing_service/signing_service/exceptions.py
+++ b/signing_service/signing_service/exceptions.py
@@ -13,3 +13,7 @@ class SigningServiceMaximumReconnectionAttemptsExceeded(Exception):
 
 class Base64DecodeError(Exception):
     pass
+
+
+class BytesToStringDecodeError(Exception):
+    pass

--- a/signing_service/signing_service/signing_service.py
+++ b/signing_service/signing_service/signing_service.py
@@ -517,19 +517,19 @@ def _parse_arguments() -> argparse.Namespace:
     ethereum_private_key_parser_group.add_argument(  # type: ignore
         '--ethereum-private-key',
         dest='ethereum_private_key',
-        action=make_secret_provider_factory(read_command_line=True, base64_convert=True, string_decode=True),
+        action=make_secret_provider_factory(read_command_line=True, base64_convert=True, decode_to_string=True),
         help='Ethereum private key for Singing Service.',
     )
     ethereum_private_key_parser_group.add_argument(  # type: ignore
         '--ethereum-private-key-path',
         dest='ethereum_private_key',
-        action=make_secret_provider_factory(use_file=True, base64_convert=True, string_decode=True),
+        action=make_secret_provider_factory(use_file=True, base64_convert=True, decode_to_string=True),
         help='Ethereum private key for Singing Service.',
     )
     ethereum_private_key_parser_group.add_argument(  # type: ignore
         '--ethereum-private-key-from-env',
         dest='ethereum_private_key',
-        action=make_secret_provider_factory(env_variable_name='ETHEREUM_PRIVATE_KEY', base64_convert=True, string_decode=True),
+        action=make_secret_provider_factory(env_variable_name='ETHEREUM_PRIVATE_KEY', base64_convert=True, decode_to_string=True),
         help='Ethereum private key for Singing Service.',
     )
 

--- a/signing_service/signing_service/utils.py
+++ b/signing_service/signing_service/utils.py
@@ -20,6 +20,7 @@ from golem_messages.exceptions import InvalidKeys
 
 from signing_service.constants import ETHEREUM_PRIVATE_KEY_REGEXP
 from signing_service.exceptions import Base64DecodeError
+from signing_service.exceptions import BytesToStringDecodeError
 
 logger = logging.getLogger()
 
@@ -54,7 +55,7 @@ def make_secret_provider_factory(
     env_variable_name: Union[str, None]=None,
     use_file: bool=False,
     base64_convert: bool=False,
-    string_decode: bool=False,
+    decode_to_string: bool=False,
 ) -> Callable:
     def wrapper(**kwargs: Any) -> 'SecretProvider':
         return SecretProvider(
@@ -62,7 +63,7 @@ def make_secret_provider_factory(
             env_variable_name,
             use_file,
             base64_convert,
-            string_decode,
+            decode_to_string,
             **kwargs
         )
     return wrapper
@@ -76,7 +77,7 @@ class SecretProvider(argparse.Action):
         env_variable_name: Union[str, None],
         use_file: bool,
         base64_convert: bool,
-        string_decode: bool,
+        decode_to_string: bool,
         option_strings: list,
         dest: str,
         required: bool=False,
@@ -86,7 +87,7 @@ class SecretProvider(argparse.Action):
         self.env_variable_name = env_variable_name
         self.use_file = use_file
         self.base64_convert = base64_convert
-        self.string_decode = string_decode
+        self.decode_to_string = decode_to_string
 
         super().__init__(
             option_strings=option_strings,
@@ -119,8 +120,13 @@ class SecretProvider(argparse.Action):
             except binascii.Error as exception:
                 logger.error(f'Unable to decode "{self.const}", {exception}')
                 raise Base64DecodeError(f'Unable to decode "{self.const}", {exception}')
-            if self.string_decode:
-                self.const = self.const.decode()
+            if self.decode_to_string:
+                assert isinstance(self.const, bytes)
+                try:
+                    self.const = self.const.decode()
+                except UnicodeDecodeError as exception:
+                    logger.error(f'Unable to decode bytes to string "{self.const}", {exception}')
+                    raise BytesToStringDecodeError(f'Unable to decode bytes to string "{self.const}", {exception}')
         setattr(namespace, self.dest, self.const)
 
 


### PR DESCRIPTION
No issue for this.

This was caught when testing Concent on VirtualBox. When `ethereum-private-key` was badly encoded, standard exception was raised instead of a custom one.