### PR TITLE
Bugfix remove nested ttc messages validations

### DIFF
--- a/concent_api/common/helpers.py
+++ b/concent_api/common/helpers.py
@@ -210,12 +210,3 @@ def ethereum_public_key_to_address(ethereum_public_key: str) -> str:
     return to_checksum_address(
         sha3(decode_hex(ethereum_public_key))[12:].hex()
     )
-
-
-def deserialize_database_message(serialized_message: 'StoredMessage') -> message.Message:  # type: ignore # noqa
-    if isinstance(serialized_message.data, bytes):
-        return deserialize_message(serialized_message.data)
-    elif isinstance(serialized_message.data, memoryview):
-        return deserialize_message(serialized_message.data.tobytes())
-    else:
-        raise ValueError('Given serialized_messages data must be `bytes` or `memoryview` instance')

--- a/concent_api/core/models.py
+++ b/concent_api/core/models.py
@@ -32,7 +32,6 @@ from common.constants import ConcentUseCase
 from common.exceptions import ConcentInSoftShutdownMode
 from common.fields import Base64Field
 from common.fields import ChoiceEnum
-from common.helpers import deserialize_database_message
 from common.helpers import deserialize_message
 from common.helpers import parse_datetime_to_timestamp
 
@@ -42,7 +41,6 @@ from .constants import ETHEREUM_TRANSACTION_HASH_LENGTH
 from .constants import GOLEM_PUBLIC_KEY_LENGTH
 from .constants import MESSAGE_TASK_ID_MAX_LENGTH
 from .constants import TASK_OWNER_KEY_LENGTH
-from .validation import validate_database_task_to_compute
 
 
 class SubtaskWithTimingColumnsManager(Manager):
@@ -520,25 +518,6 @@ class Subtask(Model):
             raise ValidationError({
                 'computation_deadline': "TaskToCompute deadline mismatch"
             })
-
-        # Validation for every nested message which is stored in Control database
-        # Every nested message must be the same as message stored separately.
-        MESSAGES_TO_VALIDATE_TASK_TO_COMPUTE = [
-            self.report_computed_task,
-            self.subtask_results_accepted,
-            self.reject_report_computed_task,
-            self.ack_report_computed_task,
-            self.subtask_results_rejected,
-            self.force_get_task_result,
-            self.subtask_results_accepted,
-        ]
-
-        for task_to_compute_to_validate in MESSAGES_TO_VALIDATE_TASK_TO_COMPUTE:
-            if task_to_compute_to_validate is not None:
-                validate_database_task_to_compute(
-                    task_to_compute=deserialized_task_to_compute,
-                    message_to_compare=deserialize_database_message(task_to_compute_to_validate),
-                )
 
         for related_message_name in Subtask.MESSAGE_FOR_FIELD:
             related_message = getattr(self, related_message_name)

--- a/concent_api/core/tests/test_unit_model.py
+++ b/concent_api/core/tests/test_unit_model.py
@@ -31,7 +31,7 @@ from core.utils import hex_to_bytes_convert
 
 # This all data has to be prepared in separate function because pytest parametrize can't get variables from SetUp()
 # Function allows to prepare 2 packs of data: correct and incorrect.
-def _get_data_list(correct):
+def _get_data_list():
     task_to_compute = factories.tasks.TaskToComputeFactory(sign__privkey=REQUESTOR_PRIVATE_KEY)
     different_task_to_compute = factories.tasks.TaskToComputeFactory(sign__privkey=REQUESTOR_PRIVATE_KEY)
     report_computed_task = factories.tasks.ReportComputedTaskFactory(
@@ -127,30 +127,26 @@ def _get_data_list(correct):
         sign__privkey=REQUESTOR_PRIVATE_KEY,
         report_computed_task=different_rct_the_same_ttc
     )
-    if correct:
-        return [
-            (task_to_compute, report_computed_task, None, None, None, None),
-            (task_to_compute, report_computed_task, ack_report_computed_task, None, None, None),
-            (task_to_compute, report_computed_task, different_arct_the_same_ttc, None, None, None),
-            (task_to_compute, report_computed_task, None, reject_report_computed_task_with_task_to_compute, None, None),
-            (task_to_compute, report_computed_task, None, reject_report_computed_task_with_task_failure, None, None),
-            (task_to_compute, report_computed_task, None, reject_report_computed_task_with_cannot_compute_task, None, None),
-            (task_to_compute, report_computed_task, None, None, force_get_task_result, None),
-            (task_to_compute, report_computed_task, None, None, different_fgtr_the_same_ttc, None),
-            (task_to_compute, report_computed_task, None, None, None, subtask_results_rejected),
-            (task_to_compute, report_computed_task, None, None, None, different_srr_the_same_ttc),
-        ]
-    else:
-        return [
-            (task_to_compute, different_report_computed_task, None, None, None, None),
-            (task_to_compute, report_computed_task, different_ack_report_computed_task, None, None, None),
-            (task_to_compute, report_computed_task, None, different_reject_report_computed_task_with_task_to_compute, None, None),
-            (task_to_compute, report_computed_task, None, different_reject_report_computed_task_with_task_failure, None, None),
-            (task_to_compute, report_computed_task, None, different_reject_report_computed_task_with_cannot_compute_task, None, None),
-            (task_to_compute, report_computed_task, None, reject_report_computed_task_without_reason_and_task_to_compute, None, None),
-            (task_to_compute, report_computed_task, None, None, different_force_get_task_result, None),
-            (task_to_compute, report_computed_task, None, None, None, different_subtask_results_rejected),
-        ]
+    return [
+        (task_to_compute, report_computed_task, None, None, None, None),
+        (task_to_compute, report_computed_task, ack_report_computed_task, None, None, None),
+        (task_to_compute, report_computed_task, different_arct_the_same_ttc, None, None, None),
+        (task_to_compute, report_computed_task, None, reject_report_computed_task_with_task_to_compute, None, None),
+        (task_to_compute, report_computed_task, None, reject_report_computed_task_with_task_failure, None, None),
+        (task_to_compute, report_computed_task, None, reject_report_computed_task_with_cannot_compute_task, None, None),
+        (task_to_compute, report_computed_task, None, None, force_get_task_result, None),
+        (task_to_compute, report_computed_task, None, None, different_fgtr_the_same_ttc, None),
+        (task_to_compute, report_computed_task, None, None, None, subtask_results_rejected),
+        (task_to_compute, report_computed_task, None, None, None, different_srr_the_same_ttc),
+        (task_to_compute, different_report_computed_task, None, None, None, None),
+        (task_to_compute, report_computed_task, different_ack_report_computed_task, None, None, None),
+        (task_to_compute, report_computed_task, None, different_reject_report_computed_task_with_task_to_compute, None, None),
+        (task_to_compute, report_computed_task, None, different_reject_report_computed_task_with_task_failure, None, None),
+        (task_to_compute, report_computed_task, None, different_reject_report_computed_task_with_cannot_compute_task, None, None),
+        (task_to_compute, report_computed_task, None, reject_report_computed_task_without_reason_and_task_to_compute, None, None),
+        (task_to_compute, report_computed_task, None, None, different_force_get_task_result, None),
+        (task_to_compute, report_computed_task, None, None, None, different_subtask_results_rejected),
+    ]
 
 
 class TestSubtaskModelValidation():
@@ -164,9 +160,9 @@ class TestSubtaskModelValidation():
         'force_get_task_result',
         'subtask_results_rejected',
     ),
-        _get_data_list(correct=True)
+        _get_data_list()
     )  # pylint: disable=no-self-use
-    def test_that_storing_subtask_with_task_to_compute_nested_in_another_messages_will_not_raise_exception_when_messages_are_equal(
+    def test_that_storing_subtask_with_task_to_compute_nested_in_another_messages_will_not_raise_exception_when_messages_are_equal_or_not(
         self,
         task_to_compute,
         report_computed_task,
@@ -193,42 +189,6 @@ class TestSubtaskModelValidation():
             Subtask.objects.get(subtask_id=task_to_compute.subtask_id).delete()
         except Exception:  # pylint: disable=broad-except
             pytest.fail()
-
-    @pytest.mark.django_db
-    @pytest.mark.parametrize((
-        'task_to_compute',
-        'report_computed_task',
-        'ack_report_computed_task',
-        'reject_report_computed_task',
-        'force_get_task_result',
-        'subtask_results_rejected',
-    ),
-        _get_data_list(correct=False)
-    )  # pylint: disable=no-self-use
-    def test_that_storing_subtask_with_task_to_compute_nested_in_another_messages_will_raise_exception_when_it_is_different_from_original_task_to_compute(
-        self,
-        task_to_compute,
-        report_computed_task,
-        ack_report_computed_task,
-        reject_report_computed_task,
-        force_get_task_result,
-        subtask_results_rejected,
-    ):
-        with pytest.raises(ValidationError):
-            store_subtask(
-                task_id=task_to_compute.task_id,
-                subtask_id=task_to_compute.subtask_id,
-                provider_public_key=hex_to_bytes_convert(task_to_compute.provider_public_key),
-                requestor_public_key=hex_to_bytes_convert(task_to_compute.requestor_public_key),
-                state=Subtask.SubtaskState.ACCEPTED,
-                task_to_compute=task_to_compute,
-                report_computed_task=report_computed_task,
-                next_deadline=None,
-                ack_report_computed_task=ack_report_computed_task,
-                reject_report_computed_task=reject_report_computed_task,
-                force_get_task_result=force_get_task_result,
-                subtask_results_rejected=subtask_results_rejected,
-            )
 
 
 def store_report_computed_task_as_subtask():

--- a/concent_api/core/validation.py
+++ b/concent_api/core/validation.py
@@ -8,7 +8,6 @@ from typing import Union
 from uuid import UUID
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
 
 from golem_messages import message
 from golem_messages.exceptions import MessageError
@@ -534,18 +533,6 @@ def validate_uuid(id_: str) -> None:
             'ID must be a UUID derivative.',
             error_code=ErrorCode.MESSAGE_WRONG_UUID_VALUE,
         )
-
-
-def validate_database_task_to_compute(
-        task_to_compute: message.tasks.TaskToCompute,
-        message_to_compare: message.Message
-) -> None:
-    if message_to_compare.task_to_compute != task_to_compute:
-        raise ValidationError({
-            message_to_compare.__class__.__name__: (
-                'Nested TaskToCompute message must be the same as TaskToCompute stored separately'
-            )
-        })
 
 
 def substitute_new_report_computed_task_if_needed(


### PR DESCRIPTION
Similar to #1161 , but this time we're removing TaskToCompute message validation in Subtask model clean()